### PR TITLE
Create basic navigation of pages

### DIFF
--- a/App1/App.xaml.cpp
+++ b/App1/App.xaml.cpp
@@ -12,6 +12,7 @@ using namespace std::placeholders;
 using namespace Windows::Foundation;
 using namespace Microsoft::UI::Xaml::Controls;
 using namespace Microsoft::UI::Xaml::Navigation;
+using Microsoft::UI::Xaml::ApplicationTheme;
 
 App::App() {
     InitializeComponent();
@@ -21,6 +22,7 @@ App::App() {
     //auto handler = std::bind(&App::OnUnhandledException, this, _1, _2);
     UnhandledException({this, &App::OnUnhandledException});
 #endif
+    RequestedTheme(ApplicationTheme::Dark);
 }
 
 void App::OnUnhandledException(IInspectable const&, UnhandledExceptionEventArgs const& e) {

--- a/App1/App1.vcxproj
+++ b/App1/App1.vcxproj
@@ -141,6 +141,10 @@
     <ClInclude Include="MainWindow.xaml.h">
       <DependentUpon>MainWindow.xaml</DependentUpon>
     </ClInclude>
+    <ClInclude Include="SupportPage.xaml.h">
+      <DependentUpon>SupportPage.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </ClInclude>
     <ClInclude Include="TestPage1.xaml.h">
       <DependentUpon>TestPage1.xaml</DependentUpon>
       <SubType>Code</SubType>
@@ -149,6 +153,9 @@
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml" />
     <Page Include="MainWindow.xaml" />
+    <Page Include="SupportPage.xaml">
+      <SubType>Designer</SubType>
+    </Page>
     <Page Include="TestPage1.xaml">
       <SubType>Designer</SubType>
     </Page>
@@ -164,6 +171,10 @@
       <DependentUpon>MainWindow.xaml</DependentUpon>
     </ClCompile>
     <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
+    <ClCompile Include="SupportPage.xaml.cpp">
+      <DependentUpon>SupportPage.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </ClCompile>
     <ClCompile Include="TestPage1.xaml.cpp">
       <DependentUpon>TestPage1.xaml</DependentUpon>
       <SubType>Code</SubType>
@@ -177,6 +188,10 @@
     <Midl Include="MainWindow.idl">
       <SubType>Code</SubType>
       <DependentUpon>MainWindow.xaml</DependentUpon>
+    </Midl>
+    <Midl Include="SupportPage.idl">
+      <DependentUpon>SupportPage.xaml</DependentUpon>
+      <SubType>Code</SubType>
     </Midl>
     <Midl Include="TestPage1.idl">
       <DependentUpon>TestPage1.xaml</DependentUpon>

--- a/App1/App1.vcxproj
+++ b/App1/App1.vcxproj
@@ -141,6 +141,10 @@
     <ClInclude Include="MainWindow.xaml.h">
       <DependentUpon>MainWindow.xaml</DependentUpon>
     </ClInclude>
+    <ClInclude Include="SettingsPage.xaml.h">
+      <DependentUpon>SettingsPage.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </ClInclude>
     <ClInclude Include="SupportPage.xaml.h">
       <DependentUpon>SupportPage.xaml</DependentUpon>
       <SubType>Code</SubType>
@@ -153,6 +157,9 @@
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml" />
     <Page Include="MainWindow.xaml" />
+    <Page Include="SettingsPage.xaml">
+      <SubType>Designer</SubType>
+    </Page>
     <Page Include="SupportPage.xaml">
       <SubType>Designer</SubType>
     </Page>
@@ -171,6 +178,10 @@
       <DependentUpon>MainWindow.xaml</DependentUpon>
     </ClCompile>
     <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
+    <ClCompile Include="SettingsPage.xaml.cpp">
+      <DependentUpon>SettingsPage.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </ClCompile>
     <ClCompile Include="SupportPage.xaml.cpp">
       <DependentUpon>SupportPage.xaml</DependentUpon>
       <SubType>Code</SubType>
@@ -188,6 +199,10 @@
     <Midl Include="MainWindow.idl">
       <SubType>Code</SubType>
       <DependentUpon>MainWindow.xaml</DependentUpon>
+    </Midl>
+    <Midl Include="SettingsPage.idl">
+      <DependentUpon>SettingsPage.xaml</DependentUpon>
+      <SubType>Code</SubType>
     </Midl>
     <Midl Include="SupportPage.idl">
       <DependentUpon>SupportPage.xaml</DependentUpon>

--- a/App1/App1.vcxproj
+++ b/App1/App1.vcxproj
@@ -141,6 +141,12 @@
     <ClInclude Include="MainWindow.xaml.h">
       <DependentUpon>MainWindow.xaml</DependentUpon>
     </ClInclude>
+    <ClInclude Include="RepositoryItem.h">
+      <DependentUpon>RepositoryItem.idl</DependentUpon>
+    </ClInclude>
+    <ClInclude Include="RepositoryViewModel.h">
+      <DependentUpon>RepositoryViewModel.idl</DependentUpon>
+    </ClInclude>
     <ClInclude Include="SettingsPage.xaml.h">
       <DependentUpon>SettingsPage.xaml</DependentUpon>
       <SubType>Code</SubType>
@@ -178,6 +184,12 @@
       <DependentUpon>MainWindow.xaml</DependentUpon>
     </ClCompile>
     <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
+    <ClCompile Include="RepositoryItem.cpp">
+      <DependentUpon>RepositoryItem.idl</DependentUpon>
+    </ClCompile>
+    <ClCompile Include="RepositoryViewModel.cpp">
+      <DependentUpon>RepositoryViewModel.idl</DependentUpon>
+    </ClCompile>
     <ClCompile Include="SettingsPage.xaml.cpp">
       <DependentUpon>SettingsPage.xaml</DependentUpon>
       <SubType>Code</SubType>
@@ -199,6 +211,12 @@
     <Midl Include="MainWindow.idl">
       <SubType>Code</SubType>
       <DependentUpon>MainWindow.xaml</DependentUpon>
+    </Midl>
+    <Midl Include="RepositoryItem.idl">
+      <SubType>Code</SubType>
+    </Midl>
+    <Midl Include="RepositoryViewModel.idl" >
+      <SubType>Code</SubType>
     </Midl>
     <Midl Include="SettingsPage.idl">
       <DependentUpon>SettingsPage.xaml</DependentUpon>

--- a/App1/App1.vcxproj
+++ b/App1/App1.vcxproj
@@ -141,10 +141,17 @@
     <ClInclude Include="MainWindow.xaml.h">
       <DependentUpon>MainWindow.xaml</DependentUpon>
     </ClInclude>
+    <ClInclude Include="TestPage1.xaml.h">
+      <DependentUpon>TestPage1.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml" />
     <Page Include="MainWindow.xaml" />
+    <Page Include="TestPage1.xaml">
+      <SubType>Designer</SubType>
+    </Page>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">
@@ -157,6 +164,10 @@
       <DependentUpon>MainWindow.xaml</DependentUpon>
     </ClCompile>
     <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
+    <ClCompile Include="TestPage1.xaml.cpp">
+      <DependentUpon>TestPage1.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Midl Include="App.idl">
@@ -167,6 +178,10 @@
       <SubType>Code</SubType>
       <DependentUpon>MainWindow.xaml</DependentUpon>
     </Midl>
+    <Midl Include="TestPage1.idl">
+      <DependentUpon>TestPage1.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Midl>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
@@ -176,6 +191,7 @@
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.230706.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
     <Import Project="..\packages\Microsoft.WindowsAppSDK.1.4.231008000\build\native\Microsoft.WindowsAppSDK.targets" Condition="Exists('..\packages\Microsoft.WindowsAppSDK.1.4.231008000\build\native\Microsoft.WindowsAppSDK.targets')" />
     <Import Project="..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22621.756\build\Microsoft.Windows.SDK.BuildTools.targets" Condition="Exists('..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22621.756\build\Microsoft.Windows.SDK.BuildTools.targets')" />
+    <Import Project="..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -187,5 +203,6 @@
     <Error Condition="!Exists('..\packages\Microsoft.WindowsAppSDK.1.4.231008000\build\native\Microsoft.WindowsAppSDK.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.WindowsAppSDK.1.4.231008000\build\native\Microsoft.WindowsAppSDK.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22621.756\build\Microsoft.Windows.SDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22621.756\build\Microsoft.Windows.SDK.BuildTools.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22621.756\build\Microsoft.Windows.SDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.SDK.BuildTools.10.0.22621.756\build\Microsoft.Windows.SDK.BuildTools.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.ImplementationLibrary.1.0.220914.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
   </Target>
 </Project>

--- a/App1/App1.vcxproj.filters
+++ b/App1/App1.vcxproj.filters
@@ -7,6 +7,7 @@
     <Page Include="MainWindow.xaml" />
     <Page Include="TestPage1.xaml" />
     <Page Include="SupportPage.xaml" />
+    <Page Include="SettingsPage.xaml" />
   </ItemGroup>
   <ItemGroup>
     <Midl Include="App.idl" />

--- a/App1/App1.vcxproj.filters
+++ b/App1/App1.vcxproj.filters
@@ -5,6 +5,8 @@
   </ItemGroup>
   <ItemGroup>
     <Page Include="MainWindow.xaml" />
+    <Page Include="TestPage1.xaml" />
+    <Page Include="SupportPage.xaml" />
   </ItemGroup>
   <ItemGroup>
     <Midl Include="App.idl" />
@@ -27,5 +29,8 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Natvis Include="$(MSBuildThisFileDirectory)..\..\natvis\wil.natvis" />
   </ItemGroup>
 </Project>

--- a/App1/App1.vcxproj.filters
+++ b/App1/App1.vcxproj.filters
@@ -12,13 +12,16 @@
   <ItemGroup>
     <Midl Include="App.idl" />
     <Midl Include="MainWindow.idl" />
+    <Midl Include="RepositoryItem.idl" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp" />
     <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
+    <ClCompile Include="RepositoryItem.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
+    <ClInclude Include="RepositoryItem.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Assets">

--- a/App1/MainWindow.idl
+++ b/App1/MainWindow.idl
@@ -1,12 +1,9 @@
-// Copyright (c) Microsoft Corporation and Contributors.
-// Licensed under the MIT License.
+namespace App1 {
 
-namespace App1
-{
-    [default_interface]
-    runtimeclass MainWindow : Microsoft.UI.Xaml.Window
-    {
-        MainWindow();
-        Int32 MyProperty;
-    }
+[default_interface] runtimeclass MainWindow : Microsoft.UI.Xaml.Window {
+    MainWindow();
+
+    Microsoft.UI.Xaml.Controls.Frame ShellFrame;
 }
+
+} // namespace App1

--- a/App1/MainWindow.idl
+++ b/App1/MainWindow.idl
@@ -1,8 +1,12 @@
 namespace App1 {
 
+// https://learn.microsoft.com/en-us/uwp/midl-3/intro
 [default_interface] runtimeclass MainWindow : Microsoft.UI.Xaml.Window {
     MainWindow();
 
+    UInt64 WindowHandle {
+        get;
+    };
     Microsoft.UI.Xaml.Controls.Frame ShellFrame;
 }
 

--- a/App1/MainWindow.xaml
+++ b/App1/MainWindow.xaml
@@ -8,16 +8,22 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
+    <!-- https://github.com/Lewis-Marshall/WinUI3NavigationExample -->
     <!-- see https://learn.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.symbol -->
     <!-- see https://learn.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.appbarbutton -->
     <NavigationView x:Name="navigationView"
                     ItemInvoked="on_item_invoked" IsBackEnabled="{x:Bind ShellFrame.CanGoBack, Mode=OneWay}"
-                    BackRequested="on_back_requested" IsSettingsVisible="False">
+                    BackRequested="on_back_requested" IsSettingsVisible="True">
         <NavigationView.MenuItems>
             <NavigationViewItem Content="TestPage1" Tag="TestPage1" Icon="Document" />
         </NavigationView.MenuItems>
         <NavigationView.FooterMenuItems>
-            <NavigationViewItem Content="Support" Icon="Help" Tag="Support" />
+            <NavigationViewItem Content="Support" Tag="Support" >
+                <NavigationViewItem.Icon>
+                    <!-- see https://learn.microsoft.com/en-us/windows/apps/design/style/segoe-ui-symbol-font -->
+                    <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE897;"/>
+                </NavigationViewItem.Icon>
+            </NavigationViewItem>
         </NavigationView.FooterMenuItems>
         <!-- ... -->
         <Frame x:Name="ShellFrame" />

--- a/App1/MainWindow.xaml
+++ b/App1/MainWindow.xaml
@@ -8,7 +8,18 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
-        <Button x:Name="myButton" Click="myButton_Click">Click Me</Button>
-    </StackPanel>
+    <!-- see https://learn.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.symbol -->
+    <!-- see https://learn.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.appbarbutton -->
+    <NavigationView x:Name="navigationView"
+                    ItemInvoked="on_item_invoked" IsBackEnabled="{x:Bind ShellFrame.CanGoBack, Mode=OneWay}"
+                    BackRequested="on_back_requested" IsSettingsVisible="False">
+        <NavigationView.MenuItems>
+            <NavigationViewItem Content="TestPage1" Tag="TestPage1" Icon="Document" />
+        </NavigationView.MenuItems>
+        <NavigationView.FooterMenuItems>
+            <NavigationViewItem Content="Support" Icon="Help" Tag="Support" />
+        </NavigationView.FooterMenuItems>
+        <!-- ... -->
+        <Frame x:Name="ShellFrame" />
+    </NavigationView>
 </Window>

--- a/App1/MainWindow.xaml.cpp
+++ b/App1/MainWindow.xaml.cpp
@@ -47,6 +47,11 @@ void MainWindow::on_item_invoked(NavigationView const&, NavigationViewItemInvoke
         frame.Navigate(name, params);
         return;
     }
+    if (item == L"Support") {
+        TypeName name{L"App1.SupportPage", TypeKind::Custom};
+        frame.Navigate(name, params);
+        return;
+    }
 }
 
 void MainWindow::on_back_requested(NavigationView const&, NavigationViewBackRequestedEventArgs const&) {

--- a/App1/MainWindow.xaml.cpp
+++ b/App1/MainWindow.xaml.cpp
@@ -4,27 +4,56 @@
 #if __has_include("MainWindow.g.cpp")
 #include "MainWindow.g.cpp"
 #endif
+#include <microsoft.ui.xaml.window.h>
+
+#include <spdlog/spdlog.h>
 
 namespace winrt::App1::implementation {
 
 using Microsoft::UI::Xaml::Controls::Button;
+using Windows::UI::Xaml::Interop::TypeKind;
+using Windows::UI::Xaml::Interop::TypeName;
 
 MainWindow::MainWindow() {
     InitializeComponent();
+    // see
+    // https://learn.microsoft.com/en-us/windows/apps/develop/ui-input/retrieve-hwnd
+    auto native = this->try_as<::IWindowNative>();
+    if (auto hr = native->get_WindowHandle(&hwnd); FAILED(hr))
+        winrt::throw_hresult(hr);
+    spdlog::info("{}: HWND {:p}", "MainWindow", static_cast<void*>(hwnd));
 }
 
-int32_t MainWindow::MyProperty() {
-    throw winrt::hresult_not_implemented();
+void MainWindow::on_window_size_changed(IInspectable const&, WindowSizeChangedEventArgs const& e) {
+    auto s = e.Size();
+    spdlog::info("{}: size ({:.2f},{:.2f})", "MainWindow", s.Width, s.Height);
 }
 
-void MainWindow::MyProperty(int32_t) {
-    throw winrt::hresult_not_implemented();
+void MainWindow::on_window_visibility_changed(IInspectable const&, WindowVisibilityChangedEventArgs const& e) {
+    spdlog::info("{}: visibility {}", "MainWindow", e.Visible());
 }
 
-void MainWindow::myButton_Click(IInspectable const&, RoutedEventArgs const&) {
-    Button button = myButton();
-    IInspectable text = winrt::box_value(L"Clicked");
-    button.Content(text);
+void MainWindow::on_item_invoked(NavigationView const&, NavigationViewItemInvokedEventArgs const& e) {
+    spdlog::info("{}: {}", "MainWindow", __func__);
+    auto item = e.InvokedItem().as<winrt::hstring>();
+    // see XamlTypeInfo.g.cpp
+    // see https://learn.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.frame.navigate
+    Frame frame = ShellFrame();
+    // there are very limited types for params... read the document above.
+    uintptr_t ptr = reinterpret_cast<uintptr_t>(this);
+    IInspectable params = winrt::box_value(ptr);
+    if (item == L"TestPage1") {
+        TypeName name{L"App1.TestPage1", TypeKind::Custom};
+        frame.Navigate(name, params);
+        return;
+    }
+}
+
+void MainWindow::on_back_requested(NavigationView const&, NavigationViewBackRequestedEventArgs const&) {
+    spdlog::info("{}: {}", "MainWindow", __func__);
+    Frame frame = ShellFrame();
+    if (frame.CanGoBack())
+        frame.GoBack();
 }
 
 } // namespace winrt::App1::implementation

--- a/App1/MainWindow.xaml.h
+++ b/App1/MainWindow.xaml.h
@@ -1,6 +1,8 @@
 #pragma once
 #include "MainWindow.g.h"
 
+#include <Windows.h>
+
 namespace winrt::App1::implementation {
 using Microsoft::UI::Xaml::RoutedEventArgs;
 using Microsoft::UI::Xaml::Window;
@@ -22,6 +24,8 @@ struct MainWindow : MainWindowT<MainWindow> {
 
   public:
     MainWindow();
+
+    uint64_t WindowHandle() const noexcept;
 
     void on_window_size_changed(IInspectable const& sender, WindowSizeChangedEventArgs const& e);
     void on_window_visibility_changed(IInspectable const& sender, WindowVisibilityChangedEventArgs const& e);

--- a/App1/MainWindow.xaml.h
+++ b/App1/MainWindow.xaml.h
@@ -2,18 +2,31 @@
 #include "MainWindow.g.h"
 
 namespace winrt::App1::implementation {
-
 using Microsoft::UI::Xaml::RoutedEventArgs;
+using Microsoft::UI::Xaml::Window;
+using Microsoft::UI::Xaml::WindowSizeChangedEventArgs;
+using Microsoft::UI::Xaml::WindowVisibilityChangedEventArgs;
+using Microsoft::UI::Xaml::Controls::Frame;
+using Microsoft::UI::Xaml::Controls::NavigationView;
+using Microsoft::UI::Xaml::Controls::NavigationViewBackRequestedEventArgs;
+using Microsoft::UI::Xaml::Controls::NavigationViewItem;
+using Microsoft::UI::Xaml::Controls::NavigationViewItemInvokedEventArgs;
+using Microsoft::UI::Xaml::Controls::Page;
+using Windows::Foundation::IAsyncAction;
 using Windows::Foundation::IInspectable;
 
 /// @see http://aka.ms/winui-project-info
 struct MainWindow : MainWindowT<MainWindow> {
+  private:
+    HWND hwnd = nullptr;
+
+  public:
     MainWindow();
 
-    int32_t MyProperty();
-    void MyProperty(int32_t value);
-
-    void myButton_Click(IInspectable const& sender, RoutedEventArgs const& args);
+    void on_window_size_changed(IInspectable const& sender, WindowSizeChangedEventArgs const& e);
+    void on_window_visibility_changed(IInspectable const& sender, WindowVisibilityChangedEventArgs const& e);
+    void on_item_invoked(NavigationView const&, NavigationViewItemInvokedEventArgs const&);
+    void on_back_requested(NavigationView const&, NavigationViewBackRequestedEventArgs const&);
 };
 
 } // namespace winrt::App1::implementation

--- a/App1/RepositoryItem.cpp
+++ b/App1/RepositoryItem.cpp
@@ -1,0 +1,68 @@
+#include "pch.h"
+
+#include "RepositoryItem.h"
+#if __has_include("RepositoryItem.g.cpp")
+#include "RepositoryItem.g.cpp"
+#endif
+#include "winrt_fmt_helper.hpp"
+#include <fmt/format.h>
+
+namespace winrt::App1::implementation {
+
+RepositoryItem::RepositoryItem(std::wstring_view host, std::wstring_view owner, std::wstring_view name)
+    : RepositoryItem{} {
+    this->host = winrt::hstring{host};
+    this->owner = winrt::hstring{owner};
+    this->name = winrt::hstring{name};
+}
+
+winrt::event_token RepositoryItem::PropertyChanged(PropertyChangedEventHandler const& value) {
+    return on_property_changed.add(value);
+}
+
+void RepositoryItem::PropertyChanged(winrt::event_token const& token) {
+    on_property_changed.remove(token);
+}
+
+winrt::hstring RepositoryItem::Host() {
+    return host;
+}
+
+void RepositoryItem::Host(winrt::hstring const& value) {
+    if (host == value)
+        return;
+    host = value;
+    on_property_changed(*this, PropertyChangedEventArgs{L"Host"});
+}
+
+winrt::hstring RepositoryItem::Owner() {
+    return owner;
+}
+
+void RepositoryItem::Owner(winrt::hstring const& value) {
+    if (owner == value)
+        return;
+    owner = value;
+    on_property_changed(*this, PropertyChangedEventArgs{L"Owner"});
+}
+
+winrt::hstring RepositoryItem::Name() {
+    return name;
+}
+
+void RepositoryItem::Name(winrt::hstring const& value) {
+    if (name == value)
+        return;
+    name = value;
+    on_property_changed(*this, PropertyChangedEventArgs{L"Name"});
+}
+
+Uri RepositoryItem::ProjectUri() {
+    std::wstring value = fmt::format(L"https://{}/{}/{}",                   //
+                                     static_cast<std::wstring_view>(host),  //
+                                     static_cast<std::wstring_view>(owner), //
+                                     static_cast<std::wstring_view>(name));
+    return Uri{value};
+}
+
+} // namespace winrt::App1::implementation

--- a/App1/RepositoryItem.h
+++ b/App1/RepositoryItem.h
@@ -1,0 +1,44 @@
+#pragma once
+#include "RepositoryItem.g.h"
+
+#include <winrt/Microsoft.UI.Xaml.Data.h>
+#include <winrt/Windows.Foundation.Collections.h>
+
+namespace winrt::App1::implementation {
+using Microsoft::UI::Xaml::Data::PropertyChangedEventArgs;
+using Microsoft::UI::Xaml::Data::PropertyChangedEventHandler;
+using Windows::Foundation::Uri;
+using Windows::Foundation::Collections::IObservableVector;
+using Windows::Foundation::Collections::IVector;
+
+struct RepositoryItem : RepositoryItemT<RepositoryItem> {
+  private:
+    winrt::hstring host;
+    winrt::hstring name;
+    winrt::hstring owner;
+    winrt::event<PropertyChangedEventHandler> on_property_changed{};
+
+  public:
+    RepositoryItem() = default;
+    RepositoryItem(std::wstring_view host, std::wstring_view owner, std::wstring_view name);
+
+    winrt::hstring Host();
+    void Host(winrt::hstring const& value);
+
+    winrt::hstring Owner();
+    void Owner(winrt::hstring const& value);
+
+    winrt::hstring Name();
+    void Name(winrt::hstring const& value);
+
+    Uri ProjectUri();
+
+    winrt::event_token PropertyChanged(PropertyChangedEventHandler const& value);
+    void PropertyChanged(winrt::event_token const& token);
+};
+
+} // namespace winrt::App1::implementation
+
+namespace winrt::App1::factory_implementation {
+struct RepositoryItem : RepositoryItemT<RepositoryItem, implementation::RepositoryItem> {};
+} // namespace winrt::App1::factory_implementation

--- a/App1/RepositoryItem.idl
+++ b/App1/RepositoryItem.idl
@@ -1,0 +1,15 @@
+namespace App1 {
+
+runtimeclass RepositoryItem : Microsoft.UI.Xaml.Data.INotifyPropertyChanged {
+    RepositoryItem();
+
+    String Host;
+    String Owner;
+    String Name;
+
+    Windows.Foundation.Uri ProjectUri {
+        get;
+    };
+}
+
+} // namespace App1

--- a/App1/RepositoryViewModel.cpp
+++ b/App1/RepositoryViewModel.cpp
@@ -1,0 +1,25 @@
+#include "pch.h"
+
+#include "RepositoryViewModel.h"
+#if __has_include("RepositoryViewModel.g.cpp")
+#include "RepositoryViewModel.g.cpp"
+#endif
+#include "RepositoryItem.h"
+
+#include <spdlog/spdlog.h>
+
+namespace winrt::App1::implementation {
+
+RepositoryViewModel::RepositoryViewModel() {
+  items = winrt::single_threaded_observable_vector<App1::RepositoryItem>();
+  items.Append(
+      winrt::make<implementation::RepositoryItem>(L"github.com", L"microsoft", L"vcpkg"));
+  items.Append(
+      winrt::make<implementation::RepositoryItem>(L"github.com",L"conan-io", L"conan"));
+}
+
+IObservableVector<App1::RepositoryItem> RepositoryViewModel::Repositories() {
+  return items;
+}
+
+} // namespace winrt::App1::implementation

--- a/App1/RepositoryViewModel.h
+++ b/App1/RepositoryViewModel.h
@@ -1,0 +1,28 @@
+#pragma once
+#include "RepositoryViewModel.g.h"
+
+#include <winrt/Microsoft.UI.Xaml.Data.h>
+#include <winrt/Windows.Foundation.Collections.h>
+
+namespace winrt::App1::implementation {
+using Microsoft::UI::Xaml::Data::PropertyChangedEventArgs;
+using Microsoft::UI::Xaml::Data::PropertyChangedEventHandler;
+using Windows::Foundation::Collections::IObservableVector;
+using Windows::Foundation::Collections::IVector;
+
+struct RepositoryViewModel : RepositoryViewModelT<RepositoryViewModel> {
+private:
+  IObservableVector<App1::RepositoryItem> items;
+
+public:
+  RepositoryViewModel();
+
+  IObservableVector<App1::RepositoryItem> Repositories();
+};
+} // namespace winrt::App1::implementation
+
+namespace winrt::App1::factory_implementation {
+struct RepositoryViewModel
+    : RepositoryViewModelT<RepositoryViewModel,
+                           implementation::RepositoryViewModel> {};
+} // namespace winrt::App1::factory_implementation

--- a/App1/RepositoryViewModel.idl
+++ b/App1/RepositoryViewModel.idl
@@ -1,0 +1,13 @@
+import "RepositoryItem.idl";
+
+namespace App1 {
+
+runtimeclass RepositoryViewModel {
+  RepositoryViewModel();
+
+  IObservableVector<RepositoryItem> Repositories {
+    get;
+  };
+}
+
+} // namespace App1

--- a/App1/SettingsPage.idl
+++ b/App1/SettingsPage.idl
@@ -1,0 +1,7 @@
+namespace App1 {
+
+[default_interface] runtimeclass SettingsPage : Microsoft.UI.Xaml.Controls.Page {
+    SettingsPage();
+}
+
+} // namespace App1

--- a/App1/SettingsPage.xaml
+++ b/App1/SettingsPage.xaml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Page
+    x:Class="App1.SettingsPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:App1"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <StackPanel
+        Orientation="Vertical" 
+        HorizontalAlignment="Stretch" 
+        VerticalAlignment="Top" 
+        Margin="16" >
+        <TextBlock
+            Text="Settings" 
+            FontFamily="Segoe UI"
+            FontSize="32" 
+            Padding="8"/>
+        <Rectangle
+            HorizontalAlignment="Stretch" 
+            Fill="{StaticResource SystemAccentColorDark1}" 
+            Height="1"/>
+        <StackPanel 
+            Orientation="Horizontal" 
+            HorizontalAlignment="Stretch" 
+            Padding="0,10,0,10"
+            Spacing="8">
+            <TextBlock MinWidth="100" 
+                       MaxWidth="150" 
+                       VerticalAlignment="Center"
+                       Text="ApplicationTheme"/>
+            <DropDownButton Content="Dark">
+                <DropDownButton.Flyout>
+                    <MenuFlyout Placement="Bottom">
+                        <MenuFlyoutItem Text="Dark"/>
+                        <MenuFlyoutItem Text="Light"/>
+                    </MenuFlyout>
+                </DropDownButton.Flyout>
+            </DropDownButton>
+        </StackPanel>
+        <RelativePanel>
+            <TextBlock
+                RelativePanel.AlignLeftWithPanel="True"
+                RelativePanel.AlignVerticalCenterWithPanel="True"
+                MinWidth="100" 
+                MaxWidth="150" 
+                VerticalAlignment="Center"
+                Text="ToggleSwitch"/>
+            <ToggleSwitch 
+                RelativePanel.AlignRightWithPanel="True"
+                RelativePanel.AlignVerticalCenterWithPanel="True"
+                OffContent="Off"
+                OnContent="On"
+                IsOn="False" />
+        </RelativePanel>
+    </StackPanel>
+</Page>

--- a/App1/SettingsPage.xaml.cpp
+++ b/App1/SettingsPage.xaml.cpp
@@ -1,0 +1,30 @@
+#include "pch.h"
+
+#include "SettingsPage.xaml.h"
+#if __has_include("SettingsPage.g.cpp")
+#include "SettingsPage.g.cpp"
+#endif
+#include "MainWindow.xaml.h"
+
+namespace winrt::App1::implementation {
+using namespace Microsoft::UI::Xaml;
+
+SettingsPage::SettingsPage() {
+    // ...
+}
+
+void SettingsPage::OnNavigatedTo(const NavigationEventArgs& e) {
+    auto ptr = winrt::unbox_value<uintptr_t>(e.Parameter());
+    auto window = reinterpret_cast<implementation::MainWindow*>(ptr);
+    if (window == nullptr)
+        return;
+    HWND hwnd = reinterpret_cast<HWND>(window->WindowHandle());
+    if (hwnd == nullptr)
+        return;
+}
+
+void SettingsPage::OnNavigatedFrom(const NavigationEventArgs&) {
+    // ... leaving the page via navigation ...
+}
+
+} // namespace winrt::App1::implementation

--- a/App1/SettingsPage.xaml.h
+++ b/App1/SettingsPage.xaml.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "SettingsPage.g.h"
+
+namespace winrt::App1::implementation {
+using Microsoft::UI::Xaml::Navigation::NavigationEventArgs;
+
+struct SettingsPage : SettingsPageT<SettingsPage> {
+    SettingsPage();
+
+    void OnNavigatedTo(const NavigationEventArgs& e);
+    void OnNavigatedFrom(const NavigationEventArgs&);
+};
+} // namespace winrt::App1::implementation
+
+namespace winrt::App1::factory_implementation {
+struct SettingsPage : SettingsPageT<SettingsPage, implementation::SettingsPage> {};
+} // namespace winrt::App1::factory_implementation

--- a/App1/SupportPage.idl
+++ b/App1/SupportPage.idl
@@ -1,0 +1,7 @@
+namespace App1 {
+
+[default_interface] runtimeclass SupportPage : Microsoft.UI.Xaml.Controls.Page {
+    SupportPage();
+}
+
+} // namespace App1

--- a/App1/SupportPage.xaml
+++ b/App1/SupportPage.xaml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Page
+    x:Class="App1.SupportPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:App1"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
+        <Button x:Name="myButton" Click="myButton_Click">Support</Button>
+    </StackPanel>
+</Page>

--- a/App1/SupportPage.xaml.cpp
+++ b/App1/SupportPage.xaml.cpp
@@ -1,0 +1,20 @@
+#include "pch.h"
+
+#include "SupportPage.xaml.h"
+#if __has_include("SupportPage.g.cpp")
+#include "SupportPage.g.cpp"
+#endif
+#include <spdlog/spdlog.h>
+
+namespace winrt::App1::implementation {
+using namespace Microsoft::UI::Xaml;
+
+SupportPage::SupportPage() {
+    // ...
+}
+
+void SupportPage::myButton_Click(IInspectable const&, RoutedEventArgs const&) {
+    myButton().Content(box_value(L"Support!"));
+}
+
+} // namespace winrt::App1::implementation

--- a/App1/SupportPage.xaml.h
+++ b/App1/SupportPage.xaml.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "SupportPage.g.h"
+
+namespace winrt::App1::implementation {
+
+struct SupportPage : SupportPageT<SupportPage> {
+    SupportPage();
+
+    void myButton_Click(IInspectable const& sender, Microsoft::UI::Xaml::RoutedEventArgs const& args);
+};
+
+} // namespace winrt::App1::implementation
+
+namespace winrt::App1::factory_implementation {
+struct SupportPage : SupportPageT<SupportPage, implementation::SupportPage> {};
+} // namespace winrt::App1::factory_implementation

--- a/App1/TestPage1.idl
+++ b/App1/TestPage1.idl
@@ -1,0 +1,7 @@
+namespace App1 {
+
+[default_interface] runtimeclass TestPage1 : Microsoft.UI.Xaml.Controls.Page {
+    TestPage1();
+}
+
+} // namespace App1

--- a/App1/TestPage1.idl
+++ b/App1/TestPage1.idl
@@ -1,7 +1,13 @@
+import "RepositoryViewModel.idl";
+
 namespace App1 {
 
 [default_interface] runtimeclass TestPage1 : Microsoft.UI.Xaml.Controls.Page {
     TestPage1();
+
+    RepositoryViewModel ViewModel0 {
+        get;
+    };
 }
 
 } // namespace App1

--- a/App1/TestPage1.xaml
+++ b/App1/TestPage1.xaml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Page
+    x:Class="App1.TestPage1"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:App1"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d" Loaded="Page_Loaded" Unloaded="Page_Unloaded">
+
+    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
+        <Button x:Name="myButton" Click="myButton_Click">Click Me</Button>
+    </StackPanel>
+</Page>

--- a/App1/TestPage1.xaml
+++ b/App1/TestPage1.xaml
@@ -8,7 +8,58 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d" Loaded="Page_Loaded" Unloaded="Page_Unloaded">
 
-    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
-        <Button x:Name="myButton" Click="myButton_Click">Click Me</Button>
+
+    <StackPanel
+        Orientation="Vertical"
+        HorizontalAlignment="Stretch"
+        VerticalAlignment="Top">
+        <TextBlock
+            Text="TestPage1" 
+            FontFamily="Segoe UI"
+            FontSize="32" 
+            Padding="8"/>
+        <Rectangle
+            HorizontalAlignment="Stretch" 
+            Fill="{StaticResource SystemAccentColorDark2}" 
+            Height="1"/>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button x:Name="OpenButton" Height="40" Click="on_button_clicked" >
+                <StackPanel Orientation="Horizontal">
+                    <Image Source="Assets/StoreLogo.png" Width="24" Height="24" Margin="0,0,5,0" />
+                    <TextBlock Text="Open" VerticalAlignment="Center"/>
+                </StackPanel>
+            </Button>
+        </StackPanel>
+        <ListView x:Name="repoListView" ItemsSource="{x:Bind ViewModel0.Repositories}" SelectionChanged="on_selection_changed">
+            <ListView.HeaderTemplate>
+                <DataTemplate>
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="150"/>
+                            <ColumnDefinition Width="150"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" Margin="15,0,0,0" FontWeight="Bold" Text="Host"/>
+                        <TextBlock Grid.Column="1" Margin="15,0,0,0" FontWeight="Bold" Text="Owner"/>
+                        <TextBlock Grid.Column="2" Margin="15,0,0,0" FontWeight="Bold" Text="Name"/>
+                    </Grid>
+                </DataTemplate>
+            </ListView.HeaderTemplate>
+            <ListView.ItemTemplate>
+                <DataTemplate x:DataType="local:RepositoryItem">
+                    <Grid Height="40">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="150"/>
+                            <ColumnDefinition Width="150"/>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="40"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" VerticalAlignment="Center" Text="{x:Bind Host, Mode=OneWay}"/>
+                        <TextBlock Grid.Column="1" VerticalAlignment="Center" Text="{x:Bind Owner, Mode=OneWay}"/>
+                        <TextBlock Grid.Column="2" VerticalAlignment="Center" Text="{x:Bind Name, Mode=OneWay}"/>
+                    </Grid>
+                </DataTemplate>
+            </ListView.ItemTemplate>
+        </ListView>
     </StackPanel>
 </Page>

--- a/App1/TestPage1.xaml.cpp
+++ b/App1/TestPage1.xaml.cpp
@@ -1,0 +1,28 @@
+#include "pch.h"
+
+#include "TestPage1.xaml.h"
+#if __has_include("TestPage1.g.cpp")
+#include "TestPage1.g.cpp"
+#endif
+#include <spdlog/spdlog.h>
+
+namespace winrt::App1::implementation {
+using namespace Microsoft::UI::Xaml;
+
+TestPage1::TestPage1() {
+    //...
+}
+
+/// @see after OnNavigatedTo, prepare some resources
+void TestPage1::Page_Loaded(IInspectable const&, RoutedEventArgs const&) {
+    spdlog::info("{}: {}", "TestPage1", __func__);
+}
+
+void TestPage1::Page_Unloaded(IInspectable const&, RoutedEventArgs const&) {
+    spdlog::info("{}: {}", "TestPage1", __func__);
+}
+
+void TestPage1::myButton_Click(IInspectable const&, RoutedEventArgs const&) {
+    myButton().Content(box_value(L"Clicked"));
+}
+} // namespace winrt::App1::implementation

--- a/App1/TestPage1.xaml.cpp
+++ b/App1/TestPage1.xaml.cpp
@@ -10,6 +10,8 @@ namespace winrt::App1::implementation {
 using namespace Microsoft::UI::Xaml;
 
 TestPage1::TestPage1() {
+    InitializeComponent();
+    viewmodel0 = winrt::make<App1::implementation::RepositoryViewModel>();
     //...
 }
 
@@ -22,7 +24,26 @@ void TestPage1::Page_Unloaded(IInspectable const&, RoutedEventArgs const&) {
     spdlog::info("{}: {}", "TestPage1", __func__);
 }
 
-void TestPage1::myButton_Click(IInspectable const&, RoutedEventArgs const&) {
-    myButton().Content(box_value(L"Clicked"));
+App1::RepositoryViewModel TestPage1::ViewModel0() {
+    return viewmodel0;
+}
+
+fire_and_forget TestPage1::on_button_clicked(IInspectable const& s, RoutedEventArgs const&) {
+    if (auto button = s.try_as<Button>(); button != OpenButton())
+        spdlog::debug("{}: {}", "TestPage1", "sender is OpenButton");
+    if (selected == nullptr)
+        co_return;
+    auto launched = co_await Windows::System::Launcher::LaunchUriAsync(selected.ProjectUri());
+    if (launched == false)
+        spdlog::error("{}: {}", "TestPage1", "launch failed");
+}
+
+void TestPage1::on_selection_changed(IInspectable const& s, SelectionChangedEventArgs const&) {
+    auto view = s.try_as<Microsoft::UI::Xaml::Controls::ListView>();
+    if (view == nullptr)
+        return;
+    auto item = view.SelectedItem();
+    selected = item.try_as<RepositoryItem>();
+    spdlog::info("{}: selected {}", "TestPage1", winrt::to_string(selected.Name()));
 }
 } // namespace winrt::App1::implementation

--- a/App1/TestPage1.xaml.h
+++ b/App1/TestPage1.xaml.h
@@ -2,22 +2,32 @@
 
 #include "TestPage1.g.h"
 
+#include "RepositoryViewModel.h"
+
 namespace winrt::App1::implementation {
 using Microsoft::UI::Xaml::RoutedEventArgs;
-using Microsoft::UI::Xaml::SizeChangedEventArgs;
-using Microsoft::UI::Xaml::Controls::SwapChainPanel;
+using Microsoft::UI::Xaml::Controls::Button;
+using Microsoft::UI::Xaml::Controls::SelectionChangedEventArgs;
 using Microsoft::UI::Xaml::Input::PointerRoutedEventArgs;
 using Microsoft::UI::Xaml::Input::TappedRoutedEventArgs;
 using Windows::Foundation::IAsyncAction;
 using Windows::Foundation::IInspectable;
 
 struct TestPage1 : TestPage1T<TestPage1> {
+  private:
+    App1::RepositoryViewModel viewmodel0 = nullptr;
+    App1::RepositoryItem selected = nullptr;
+
+  public:
     TestPage1();
 
     void Page_Loaded(IInspectable const&, RoutedEventArgs const&);
     void Page_Unloaded(IInspectable const&, RoutedEventArgs const&);
 
-    void myButton_Click(IInspectable const& sender, Microsoft::UI::Xaml::RoutedEventArgs const& args);
+    App1::RepositoryViewModel ViewModel0();
+
+    fire_and_forget on_button_clicked(IInspectable const&, RoutedEventArgs const&);
+    void on_selection_changed(IInspectable const&, SelectionChangedEventArgs const&);
 };
 } // namespace winrt::App1::implementation
 

--- a/App1/TestPage1.xaml.h
+++ b/App1/TestPage1.xaml.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "TestPage1.g.h"
+
+namespace winrt::App1::implementation {
+using Microsoft::UI::Xaml::RoutedEventArgs;
+using Microsoft::UI::Xaml::SizeChangedEventArgs;
+using Microsoft::UI::Xaml::Controls::SwapChainPanel;
+using Microsoft::UI::Xaml::Input::PointerRoutedEventArgs;
+using Microsoft::UI::Xaml::Input::TappedRoutedEventArgs;
+using Windows::Foundation::IAsyncAction;
+using Windows::Foundation::IInspectable;
+
+struct TestPage1 : TestPage1T<TestPage1> {
+    TestPage1();
+
+    void Page_Loaded(IInspectable const&, RoutedEventArgs const&);
+    void Page_Unloaded(IInspectable const&, RoutedEventArgs const&);
+
+    void myButton_Click(IInspectable const& sender, Microsoft::UI::Xaml::RoutedEventArgs const& args);
+};
+} // namespace winrt::App1::implementation
+
+namespace winrt::App1::factory_implementation {
+struct TestPage1 : TestPage1T<TestPage1, implementation::TestPage1> {};
+} // namespace winrt::App1::factory_implementation

--- a/App1/packages.config
+++ b/App1/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230706.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.220914.1" targetFramework="native" />
   <package id="Microsoft.Windows.SDK.BuildTools" version="10.0.22621.756" targetFramework="native" />
   <package id="Microsoft.WindowsAppSDK" version="1.4.231008000" targetFramework="native" />
 </packages>


### PR DESCRIPTION

### Changes

`MainWindow` navigates to the selected `Page`.
Referenced `XamlTypeInfo.g.cpp` file.

Supports 3 pages
* `TestPage`
* `SupportPage`
* `SettingsPage`

More implementations are required for each page.