### PR TITLE
Create SettingsViewModel and make App, SettingsPage use it

### DIFF
--- a/App1/App.xaml.cpp
+++ b/App1/App.xaml.cpp
@@ -35,12 +35,10 @@ App::~App() noexcept {
 }
 
 void App::OnUnhandledException(IInspectable const&, UnhandledExceptionEventArgs const& e) {
-    if (IsDebuggerPresent() == false)
-        // ...
-        return;
     winrt::hstring txt = e.Message();
+    if (IsDebuggerPresent())
+        __debugbreak();
     spdlog::critical(L"App: {:s}", static_cast<std::wstring_view>(txt));
-    __debugbreak();
 }
 
 void App::OnLaunched(LaunchActivatedEventArgs const&) {

--- a/App1/App.xaml.cpp
+++ b/App1/App.xaml.cpp
@@ -3,6 +3,8 @@
 #include "App.xaml.h"
 #include "MainWindow.xaml.h"
 
+#include "SettingsViewModel.h"
+
 #include <source_location>
 #define SPDLOG_WCHAR_TO_UTF8_SUPPORT
 #include <spdlog/spdlog.h>
@@ -15,15 +17,21 @@ using namespace Microsoft::UI::Xaml::Controls;
 using namespace Microsoft::UI::Xaml::Navigation;
 using Microsoft::UI::Xaml::ApplicationTheme;
 
-App::App() {
+App::App() noexcept(false) {
     InitializeComponent();
     set_log_stream("App");
-
 #if defined _DEBUG && !defined DISABLE_XAML_GENERATED_BREAK_ON_UNHANDLED_EXCEPTION
     //auto handler = std::bind(&App::OnUnhandledException, this, _1, _2);
     UnhandledException({this, &App::OnUnhandledException});
 #endif
     RequestedTheme(ApplicationTheme::Dark);
+    settings = winrt::make<implementation::SettingsViewModel>();
+    // note: the App will be the first which receives the events
+    settings_changed_token = settings.PropertyChanged({this, &App::on_settings_changed});
+}
+
+App::~App() noexcept {
+    clear_settings_event();
 }
 
 void App::OnUnhandledException(IInspectable const&, UnhandledExceptionEventArgs const& e) {
@@ -37,8 +45,25 @@ void App::OnUnhandledException(IInspectable const&, UnhandledExceptionEventArgs 
 
 void App::OnLaunched(LaunchActivatedEventArgs const&) {
     spdlog::info("App: {:s}", std::source_location::current().function_name());
-    window = make<MainWindow>();
+    auto impl = winrt::make<implementation::MainWindow>();
+    impl.Settings(settings);
+    window = impl;
     window.Activate();
+}
+
+void App::on_settings_changed(IInspectable const&, PropertyChangedEventArgs const& e) {
+    // ... reserved section. nothing to do for now ...
+    spdlog::debug(L"App: changed - {}", e.PropertyName());
+}
+
+void App::clear_settings_event() noexcept {
+    auto viewmodel = settings;
+    if (viewmodel == nullptr)
+        return;
+    if (settings_changed_token) {
+        viewmodel.PropertyChanged(settings_changed_token);
+        settings_changed_token = {};
+    }
 }
 
 } // namespace winrt::App1::implementation

--- a/App1/App.xaml.h
+++ b/App1/App.xaml.h
@@ -1,22 +1,29 @@
 #pragma once
 #include "App.xaml.g.h"
+#include "SettingsViewModel.g.h"
 
 namespace winrt::App1::implementation {
-
 using Microsoft::UI::Xaml::LaunchActivatedEventArgs;
 using Microsoft::UI::Xaml::UnhandledExceptionEventArgs;
 using Microsoft::UI::Xaml::Window;
+using Microsoft::UI::Xaml::Data::PropertyChangedEventArgs;
 using Windows::Foundation::IInspectable;
 
 struct App : AppT<App> {
-    App();
-
-    void OnLaunched(LaunchActivatedEventArgs const&);
-
-    void OnUnhandledException(IInspectable const&, UnhandledExceptionEventArgs const&);
-
   private:
     Window window = nullptr;
+    App1::SettingsViewModel settings = nullptr;
+    winrt::event_token settings_changed_token{};
+
+  public:
+    App() noexcept(false);
+    ~App() noexcept;
+
+    void OnLaunched(LaunchActivatedEventArgs const&);
+    void OnUnhandledException(IInspectable const&, UnhandledExceptionEventArgs const&);
+
+    void on_settings_changed(IInspectable const&, PropertyChangedEventArgs const&);
+    void clear_settings_event() noexcept;
 };
 
 } // namespace winrt::App1::implementation

--- a/App1/App1.vcxproj
+++ b/App1/App1.vcxproj
@@ -184,6 +184,10 @@
       <SubType>Code</SubType>
       <DependentUpon>BasicViewModel.idl</DependentUpon>
     </ClInclude>
+    <ClInclude Include="SettingsViewModel.h">
+      <SubType>Code</SubType>
+      <DependentUpon>SettingsViewModel.idl</DependentUpon>
+    </ClInclude>
     <ClInclude Include="StepTimer.h" />
     <ClInclude Include="TestPage1.xaml.h">
       <DependentUpon>TestPage1.xaml</DependentUpon>
@@ -239,6 +243,10 @@
       <SubType>Code</SubType>
       <DependentUpon>BasicViewModel.idl</DependentUpon>
     </ClCompile>
+    <ClCompile Include="SettingsViewModel.cpp">
+      <SubType>Code</SubType>
+      <DependentUpon>SettingsViewModel.idl</DependentUpon>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Midl Include="MainWindow.idl">
@@ -261,6 +269,9 @@
       <SubType>Code</SubType>
     </Midl>
     <Midl Include="BasicViewModel.idl">
+      <SubType>Code</SubType>
+    </Midl>
+    <Midl Include="SettingsViewModel.idl">
       <SubType>Code</SubType>
     </Midl>
   </ItemGroup>

--- a/App1/MainWindow.idl
+++ b/App1/MainWindow.idl
@@ -1,8 +1,15 @@
+import "SettingsViewModel.idl";
+
 namespace App1 {
 
 // https://learn.microsoft.com/en-us/uwp/midl-3/intro
 [default_interface] runtimeclass MainWindow : Microsoft.UI.Xaml.Window {
     MainWindow();
+
+    SettingsViewModel Settings {
+        get;
+        set;
+    };
 
     UInt64 WindowHandle {
         get;

--- a/App1/MainWindow.xaml.h
+++ b/App1/MainWindow.xaml.h
@@ -2,6 +2,7 @@
 #include "MainWindow.g.h"
 
 #include "BasicViewModel.g.h"
+#include "SettingsViewModel.g.h"
 
 namespace winrt::App1::implementation {
 using Microsoft::UI::Xaml::RoutedEventArgs;
@@ -14,6 +15,7 @@ using Microsoft::UI::Xaml::Controls::NavigationViewBackRequestedEventArgs;
 using Microsoft::UI::Xaml::Controls::NavigationViewItem;
 using Microsoft::UI::Xaml::Controls::NavigationViewItemInvokedEventArgs;
 using Microsoft::UI::Xaml::Controls::Page;
+using Microsoft::UI::Xaml::Data::PropertyChangedEventArgs;
 using Windows::Foundation::IAsyncAction;
 using Windows::Foundation::IInspectable;
 
@@ -21,9 +23,15 @@ using Windows::Foundation::IInspectable;
 struct MainWindow : MainWindowT<MainWindow> {
   private:
     App1::BasicViewModel viewmodel0 = nullptr;
+    App1::SettingsViewModel viewmodel1 = nullptr;
+    winrt::event_token settings_changed_token{};
 
   public:
-    MainWindow();
+    MainWindow() noexcept(false);
+    ~MainWindow() noexcept;
+
+    App1::SettingsViewModel Settings() const noexcept;
+    void Settings(App1::SettingsViewModel) noexcept(false);
 
     uint64_t WindowHandle() const noexcept;
 
@@ -31,6 +39,8 @@ struct MainWindow : MainWindowT<MainWindow> {
     void on_window_visibility_changed(IInspectable const& sender, WindowVisibilityChangedEventArgs const& e);
     void on_item_invoked(NavigationView const&, NavigationViewItemInvokedEventArgs const&);
     void on_back_requested(NavigationView const&, NavigationViewBackRequestedEventArgs const&);
+    void on_settings_changed(IInspectable const&, PropertyChangedEventArgs const&);
+    void clear_settings_event() noexcept;
 };
 
 } // namespace winrt::App1::implementation

--- a/App1/SettingsPage.idl
+++ b/App1/SettingsPage.idl
@@ -1,11 +1,11 @@
-import "BasicViewModel.idl";
+import "SettingsViewModel.idl";
 
 namespace App1 {
 
 [default_interface] runtimeclass SettingsPage : Microsoft.UI.Xaml.Controls.Page {
     SettingsPage();
 
-    BasicViewModel ViewModel();
+    SettingsViewModel ViewModel();
 }
 
 } // namespace App1

--- a/App1/SettingsPage.xaml
+++ b/App1/SettingsPage.xaml
@@ -13,34 +13,51 @@
         HorizontalAlignment="Stretch" 
         VerticalAlignment="Top" 
         Margin="16" >
-        
+
         <TextBlock Text="Application Settings" 
                    FontSize="24" 
                    FontWeight="SemiBold" 
                    Margin="0,0,0,16" />
-        
-        <TextBlock Text="Log Folder Location" 
+
+        <!-- Counter Setting -->
+        <TextBlock Text="Counter Value" 
                    FontWeight="SemiBold" 
                    Margin="0,8,0,4" />
         
         <Grid Margin="0,0,0,16">
             <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
             
-            <TextBlock x:Name="LogPathTextBlock" 
-                       FontFamily="Cascadia Mono"
-                       Text="Loading..." 
-                       TextWrapping="Wrap" 
+            <Button x:Name="DecrementButton" 
+                    Grid.Column="0" 
+                    Click="on_decrement_counter_click" 
+                    Margin="0,0,8,0"
+                    Content="-" 
+                    Width="40" />
+            
+            <TextBlock x:Name="CounterTextBlock" 
+                       Grid.Column="1"
+                       Text="0" 
+                       FontSize="18"
+                       TextAlignment="Center"
                        VerticalAlignment="Center" />
             
-            <Button x:Name="OpenLogFolderButton" 
-                    Grid.Column="1" 
-                    Click="on_open_log_folder_click" 
-                    ToolTipService.ToolTip="Open Log Folder">
-                <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE838;" />
-            </Button>
+            <Button x:Name="IncrementButton" 
+                    Grid.Column="2" 
+                    Click="on_increment_counter_click" 
+                    Margin="8,0,0,0"
+                    Content="+" 
+                    Width="40" />
         </Grid>
+        
+        <Button x:Name="ResetCounterButton" 
+                Click="on_reset_counter_click" 
+                Content="Reset to Default" 
+                HorizontalAlignment="Left"
+                Margin="0,0,0,24" />
+
     </StackPanel>
 </Page>

--- a/App1/SettingsPage.xaml
+++ b/App1/SettingsPage.xaml
@@ -23,28 +23,28 @@
         <TextBlock Text="Counter Value" 
                    FontWeight="SemiBold" 
                    Margin="0,8,0,4" />
-        
+
         <Grid Margin="0,0,0,16">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
-            
+
             <Button x:Name="DecrementButton" 
                     Grid.Column="0" 
                     Click="on_decrement_counter_click" 
                     Margin="0,0,8,0"
                     Content="-" 
                     Width="40" />
-            
+
             <TextBlock x:Name="CounterTextBlock" 
                        Grid.Column="1"
                        Text="0" 
                        FontSize="18"
                        TextAlignment="Center"
                        VerticalAlignment="Center" />
-            
+
             <Button x:Name="IncrementButton" 
                     Grid.Column="2" 
                     Click="on_increment_counter_click" 
@@ -52,7 +52,7 @@
                     Content="+" 
                     Width="40" />
         </Grid>
-        
+
         <Button x:Name="ResetCounterButton" 
                 Click="on_reset_counter_click" 
                 Content="Reset to Default" 

--- a/App1/SettingsPage.xaml.cpp
+++ b/App1/SettingsPage.xaml.cpp
@@ -12,49 +12,64 @@ namespace winrt::App1::implementation {
 
 using Windows::Foundation::Uri;
 using Windows::System::Launcher;
+using Microsoft::UI::Xaml::Data::PropertyChangedEventArgs;
 
-SettingsPage::SettingsPage() {
-    // ...
-}
-
-App1::BasicViewModel SettingsPage::ViewModel() noexcept {
+App1::SettingsViewModel SettingsPage::ViewModel() noexcept {
     return viewmodel0;
 }
 
-fire_and_forget SettingsPage::OnNavigatedTo(const NavigationEventArgs& e) {
+void SettingsPage::OnNavigatedTo(const NavigationEventArgs& e) {
     IInspectable arg0 = e.Parameter();
     if (arg0 == nullptr)
         throw std::runtime_error("SettingsPage requires a ViewModel");
+    viewmodel0 = arg0.try_as<App1::SettingsViewModel>();
 
-    viewmodel0 = arg0.try_as<App1::BasicViewModel>();
-    CreateLogFolderAsync();
-}
-
-fire_and_forget SettingsPage::CreateLogFolderAsync() {
-    using Microsoft::UI::Dispatching::DispatcherQueue;
-    auto foreground = DispatcherQueue::GetForCurrentThread();
-    co_await viewmodel0.CreateLogFolderAsync();
-    co_await resume_on_ui{foreground};
-    UpdateLogFolderPath();
-}
-
-void SettingsPage::UpdateLogFolderPath() {
-    // ...
-    LogPathTextBlock().Text(viewmodel0.GetLogFolderPath());
+    // Connect to property changed events
+    if (viewmodel0 != nullptr) {
+        property_changed_token = viewmodel0.PropertyChanged({this, &SettingsPage::on_settings_property_changed});
+        UpdateCounterDisplay();
+    }
 }
 
 void SettingsPage::OnNavigatedFrom(const NavigationEventArgs&) {
-    viewmodel0 = nullptr; // leaving. no more ViewModel access
+    // Disconnect from property changed events
+    if (viewmodel0 != nullptr && property_changed_token) {
+        viewmodel0.PropertyChanged(property_changed_token);
+        property_changed_token = {};
+    }
+    viewmodel0 = nullptr;
 }
 
-void SettingsPage::on_open_log_folder_click(IInspectable const&, RoutedEventArgs const&) {
-    try {
-        App1::BasicViewModel viewmodel = ViewModel();
-        StorageFolder folder = viewmodel.GetLogFolder();
-        if (folder != nullptr)
-            Launcher::LaunchFolderAsync(folder);
-    } catch (const winrt::hresult_error& ex) {
-        spdlog::error(L"{}", static_cast<std::wstring_view>(ex.message()));
+void SettingsPage::UpdateCounterDisplay() {
+    if (viewmodel0 != nullptr) {
+        CounterTextBlock().Text(winrt::to_hstring(viewmodel0.Counter()));
+    }
+}
+
+void SettingsPage::on_settings_property_changed(IInspectable const&, Microsoft::UI::Xaml::Data::PropertyChangedEventArgs const& e) {
+    if (e.PropertyName() == L"Counter") {
+        UpdateCounterDisplay();
+    }
+}
+
+void SettingsPage::on_increment_counter_click(IInspectable const&, RoutedEventArgs const&) {
+    if (viewmodel0 != nullptr) {
+        viewmodel0.Counter(viewmodel0.Counter() + 1);
+    }
+}
+
+void SettingsPage::on_decrement_counter_click(IInspectable const&, RoutedEventArgs const&) {
+    if (viewmodel0 != nullptr) {
+        uint32_t currentValue = viewmodel0.Counter();
+        if (currentValue > 0) {
+            viewmodel0.Counter(currentValue - 1);
+        }
+    }
+}
+
+void SettingsPage::on_reset_counter_click(IInspectable const&, RoutedEventArgs const&) {
+    if (viewmodel0 != nullptr) {
+        viewmodel0.ResetToDefault();
     }
 }
 

--- a/App1/SettingsPage.xaml.h
+++ b/App1/SettingsPage.xaml.h
@@ -1,29 +1,34 @@
 #pragma once
 
-#include "BasicViewModel.h"
 #include "SettingsPage.g.h"
+#include "SettingsViewModel.g.h"
 
 namespace winrt::App1::implementation {
 using Microsoft::UI::Xaml::RoutedEventArgs;
+using Microsoft::UI::Xaml::Data::PropertyChangedEventHandler;
+using Microsoft::UI::Xaml::Data::PropertyChangedEventArgs;
 using Microsoft::UI::Xaml::Navigation::NavigationEventArgs;
 using Windows::Foundation::IInspectable;
 
 struct SettingsPage : SettingsPageT<SettingsPage> {
   private:
-    App1::BasicViewModel viewmodel0{nullptr};
+    App1::SettingsViewModel viewmodel0{nullptr};
+    winrt::event_token property_changed_token{};
 
-    void UpdateLogFolderPath();
+    void UpdateCounterDisplay();
+    void on_settings_property_changed(IInspectable const& sender, PropertyChangedEventArgs const& e);
 
   public:
-    SettingsPage();
+    SettingsPage() noexcept = default;
 
-    fire_and_forget OnNavigatedTo(const NavigationEventArgs&);
+    void OnNavigatedTo(const NavigationEventArgs&);
     void OnNavigatedFrom(const NavigationEventArgs&);
 
-    fire_and_forget CreateLogFolderAsync();
-    App1::BasicViewModel ViewModel() noexcept;
-
-    void on_open_log_folder_click(IInspectable const&, RoutedEventArgs const&);
+    App1::SettingsViewModel ViewModel() noexcept;
+    
+    void on_increment_counter_click(IInspectable const&, RoutedEventArgs const&);
+    void on_decrement_counter_click(IInspectable const&, RoutedEventArgs const&);
+    void on_reset_counter_click(IInspectable const&, RoutedEventArgs const&);
 };
 } // namespace winrt::App1::implementation
 

--- a/App1/SettingsViewModel.cpp
+++ b/App1/SettingsViewModel.cpp
@@ -8,14 +8,10 @@
 #define SPDLOG_WCHAR_TO_UTF8_SUPPORT
 #include <spdlog/spdlog.h>
 
-using namespace winrt::Windows::Foundation;
-using namespace winrt::Windows::Foundation::Collections;
-using namespace winrt::Windows::Storage;
+namespace winrt::App1::implementation {
 using namespace winrt::Microsoft::UI::Xaml::Data;
 
-namespace winrt::App1::implementation {
-
-SettingsViewModel::SettingsViewModel() {
+SettingsViewModel::SettingsViewModel() noexcept {
     LoadSettings();
 }
 
@@ -28,11 +24,11 @@ uint32_t SettingsViewModel::Counter() const noexcept {
 }
 
 void SettingsViewModel::Counter(uint32_t value) noexcept {
-    if (counter != value) {
-        counter = value;
-        SaveSettings();
-        RaisePropertyChanged(L"Counter");
-    }
+    if (counter == value)
+        return;
+    counter = value;
+    SaveSettings();
+    RaisePropertyChanged(L"Counter");
 }
 
 void SettingsViewModel::ResetToDefault() noexcept {

--- a/App1/SettingsViewModel.cpp
+++ b/App1/SettingsViewModel.cpp
@@ -1,0 +1,87 @@
+#include "pch.h"
+
+#include "SettingsViewModel.h"
+#if __has_include("SettingsViewModel.g.cpp")
+#include "SettingsViewModel.g.cpp"
+#endif
+
+#define SPDLOG_WCHAR_TO_UTF8_SUPPORT
+#include <spdlog/spdlog.h>
+
+using namespace winrt::Windows::Foundation;
+using namespace winrt::Windows::Foundation::Collections;
+using namespace winrt::Windows::Storage;
+using namespace winrt::Microsoft::UI::Xaml::Data;
+
+namespace winrt::App1::implementation {
+
+SettingsViewModel::SettingsViewModel() {
+    LoadSettings();
+}
+
+ApplicationDataContainer SettingsViewModel::GetLocalSettings() noexcept(false) {
+    return ApplicationData::Current().LocalSettings();
+}
+
+uint32_t SettingsViewModel::Counter() const noexcept {
+    return counter;
+}
+
+void SettingsViewModel::Counter(uint32_t value) noexcept {
+    if (counter != value) {
+        counter = value;
+        SaveSettings();
+        RaisePropertyChanged(L"Counter");
+    }
+}
+
+void SettingsViewModel::ResetToDefault() noexcept {
+    Counter(0);
+    SaveSettings();
+}
+
+void SettingsViewModel::SaveSettings() noexcept {
+    try {
+        auto settings = GetLocalSettings();
+        if (settings == nullptr) {
+            spdlog::error(L"Local settings are not available.");
+            return;
+        }
+        IPropertySet values = settings.Values();
+        values.Insert(L"Counter", winrt::box_value(counter));
+    } catch (const winrt::hresult_error& ex) {
+        spdlog::error(L"SaveSettings: {}", ex.message());
+    }
+}
+
+void SettingsViewModel::LoadSettings() noexcept {
+    counter = 0; // Initialize to default value
+    try {
+        auto settings = GetLocalSettings();
+        if (settings == nullptr) {
+            spdlog::error(L"Local settings are not available.");
+            return;
+        }
+        IPropertySet values = settings.Values();
+        if (const auto key = L"Counter"; values.HasKey(key)) {
+            if (auto boxed = values.Lookup(key); boxed != nullptr)
+                counter = winrt::unbox_value<uint32_t>(boxed);
+        }
+    } catch (const winrt::hresult_error& ex) {
+        spdlog::error(L"LoadSettings: {}", ex.message());
+    }
+}
+
+winrt::event_token SettingsViewModel::PropertyChanged(PropertyChangedEventHandler const& handler) {
+    return m_propertyChanged.add(handler);
+}
+
+void SettingsViewModel::PropertyChanged(winrt::event_token const& token) noexcept {
+    m_propertyChanged.remove(token);
+}
+
+void SettingsViewModel::RaisePropertyChanged(winrt::hstring const& propertyName) {
+    m_propertyChanged(*this, PropertyChangedEventArgs(propertyName));
+}
+
+} // namespace winrt::App1::implementation

--- a/App1/SettingsViewModel.h
+++ b/App1/SettingsViewModel.h
@@ -22,25 +22,26 @@ using Windows::Storage::StorageFolder;
 struct SettingsViewModel : SettingsViewModelT<SettingsViewModel> {
   private:
     uint32_t counter = 0;
-
     winrt::event<PropertyChangedEventHandler> m_propertyChanged;
 
-    void SaveSettings() noexcept;
-    void LoadSettings() noexcept;
-    ApplicationDataContainer GetLocalSettings() noexcept(false);
-    void RaisePropertyChanged(winrt::hstring const& propertyName);
-
   public:
-    SettingsViewModel();
+    SettingsViewModel() noexcept;
 
     uint32_t Counter() const noexcept;
     void Counter(uint32_t value) noexcept;
-
     void ResetToDefault() noexcept;
 
     // INotifyPropertyChanged implementation
-    winrt::event_token PropertyChanged(PropertyChangedEventHandler const& handler);
-    void PropertyChanged(winrt::event_token const& token) noexcept;
+    winrt::event_token PropertyChanged(PropertyChangedEventHandler const&);
+    void PropertyChanged(winrt::event_token const&) noexcept;
+
+  private:
+    void SaveSettings() noexcept;
+    void LoadSettings() noexcept;
+
+    /// @note Declare getters in the SettingsViewModel.idl file, and limit the direct access to the ApplicationDataContainer
+    ApplicationDataContainer GetLocalSettings() noexcept(false);
+    void RaisePropertyChanged(winrt::hstring const& propertyName);
 };
 
 } // namespace winrt::App1::implementation

--- a/App1/SettingsViewModel.h
+++ b/App1/SettingsViewModel.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "SettingsViewModel.g.h"
+
+namespace winrt::App1::implementation {
+using Microsoft::UI::Xaml::Data::PropertyChangedEventHandler;
+using Windows::Foundation::IAsyncAction;
+using Windows::Foundation::Collections::IObservableVector;
+using Windows::Foundation::Collections::IPropertySet;
+using Windows::Storage::ApplicationData;
+using Windows::Storage::ApplicationDataContainer;
+using Windows::Storage::StorageFolder;
+
+/**
+ * @details Helps SettingsPage to work with the application settings
+ * @note The class won't access User or Machine settings
+ * @see https://learn.microsoft.com/en-us/windows/apps/design/app-settings/guidelines-for-app-settings
+ * @see https://learn.microsoft.com/en-us/windows/apps/design/app-settings/store-and-retrieve-app-data
+ * @see Windows.Storage.ApplicationDataContainer
+ * @see Windows.Storage.StorageFolder
+ */
+struct SettingsViewModel : SettingsViewModelT<SettingsViewModel> {
+  private:
+    uint32_t counter = 0;
+
+    winrt::event<PropertyChangedEventHandler> m_propertyChanged;
+
+    void SaveSettings() noexcept;
+    void LoadSettings() noexcept;
+    ApplicationDataContainer GetLocalSettings() noexcept(false);
+    void RaisePropertyChanged(winrt::hstring const& propertyName);
+
+  public:
+    SettingsViewModel();
+
+    uint32_t Counter() const noexcept;
+    void Counter(uint32_t value) noexcept;
+
+    void ResetToDefault() noexcept;
+
+    // INotifyPropertyChanged implementation
+    winrt::event_token PropertyChanged(PropertyChangedEventHandler const& handler);
+    void PropertyChanged(winrt::event_token const& token) noexcept;
+};
+
+} // namespace winrt::App1::implementation
+
+namespace winrt::App1::factory_implementation {
+
+struct SettingsViewModel : SettingsViewModelT<SettingsViewModel, implementation::SettingsViewModel> {};
+
+} // namespace winrt::App1::factory_implementation

--- a/App1/SettingsViewModel.idl
+++ b/App1/SettingsViewModel.idl
@@ -1,0 +1,16 @@
+
+namespace App1 {
+
+/// @see https://learn.microsoft.com/en-us/windows/apps/design/app-settings/guidelines-for-app-settings
+/// @see https://learn.microsoft.com/en-us/windows/apps/design/app-settings/store-and-retrieve-app-data
+runtimeclass SettingsViewModel : Microsoft.UI.Xaml.Data.INotifyPropertyChanged {
+    SettingsViewModel();
+
+    UInt32 Counter {
+        get;
+        set;
+    };
+    void ResetToDefault();
+}
+
+} // namespace App1


### PR DESCRIPTION
## Changes

- Create `SettingsViewModel` class and files for it
  - `SettingsPage` will use the class
  - `App` class will create `SettingsViewModel` and share it via `MainWindow` class
- Resolve #9

## References

- https://learn.microsoft.com/en-us/windows/apps/design/app-settings/guidelines-for-app-settings
- https://learn.microsoft.com/en-us/windows/apps/design/app-settings/store-and-retrieve-app-data
- #20
