### PR TITLE
CI: Report VSTest code coverage to SonarCloud

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,25 @@
 # https://docs.github.com/en/code-security/dependabot
+# https://learn.microsoft.com/en-us/vcpkg/concepts/dependabot
 version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
+    labels:
+      - "dependencies"
     assignees:
       - "luncliff"
+    commit-message:
+      prefix: "[skip ci] "
+
+  - package-ecosystem: "vcpkg"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    assignees:
+      - "luncliff"
+    labels:
+      - "dependencies"
     commit-message:
       prefix: "[skip ci] "

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -89,4 +89,4 @@ jobs:
           args: >
             --define "sonar.token=${{ secrets.SONAR_TOKEN }}"
             --define "sonar.cfamily.build-wrapper-output=bw-output"
-            --define "sonar.cfamily.vscoveragexml.reportsPath=x64/*.xml"
+            --define "sonar.cfamily.vscoveragexml.reportsPath=x64/*/*.xml"

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -1,9 +1,9 @@
 #
 # References
-#   https://github.com/sonarsource-cfamily-examples/windows-cmake-gh-actions-sc
-#   https://github.com/sonarsource-cfamily-examples/windows-msbuild-gh-actions-sc
-#   https://devblogs.microsoft.com/cppblog/vcpkg-2023-06-20-and-2023-07-21-releases-github-dependency-graph-support-android-tested-triplets-xbox-triplet-improvements-and-more
-#   https://devblogs.microsoft.com/cppblog/vcpkg-integration-with-the-github-dependency-graph
+# - https://github.com/sonarsource-cfamily-examples/windows-msbuild-gh-actions-sc
+# - https://github.com/sonarsource-cfamily-examples/windows-msbuild-vscoverage-gh-actions-sc
+# - https://docs.sonarsource.com/sonarqube-server/2025.1/analyzing-source-code/test-coverage/c-family-test-coverage
+# - https://docs.sonarsource.com/sonarqube-server/analyzing-source-code/analysis-parameters
 #
 name: Analysis
 
@@ -67,7 +67,7 @@ jobs:
         env:
           VCPKG_FEATURE_FLAGS: "registries,binarycaching,manifests"
 
-      - name: "Run VSTest(x64/Debug)" # see https://github.com/sonarsource-cfamily-examples/windows-msbuild-vscoverage-gh-actions-sc
+      - name: "Run VSTest(x64/Debug)" # https://github.com/sonarsource-cfamily-examples/windows-msbuild-vscoverage-gh-actions-sc
         run: |
           vstest.console.exe /framework:frameworkuap10 UnitTestApp1.build.appxrecipe `
             /EnableCodeCoverage /Collect:"Code Coverage;Format=Xml" "/ResultsDirectory:${{ github.workspace }}/x64"
@@ -85,7 +85,7 @@ jobs:
           path: "${{ github.workspace }}/packages"
 
       - uses: SonarSource/sonarqube-scan-action@v6
-        with: # --define sonar.verbose=true?
+        with: # todo: separate sonar.links.ci for triggers
           args: >
             --define "sonar.token=${{ secrets.SONAR_TOKEN }}"
             --define "sonar.cfamily.build-wrapper-output=bw-output"

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -70,7 +70,9 @@ jobs:
       - name: "Run VSTest(x64/Debug)" # https://github.com/sonarsource-cfamily-examples/windows-msbuild-vscoverage-gh-actions-sc
         run: |
           vstest.console.exe /framework:frameworkuap10 UnitTestApp1.build.appxrecipe `
-            /EnableCodeCoverage /Collect:"Code Coverage;Format=Xml" "/ResultsDirectory:${{ github.workspace }}/x64"
+            /EnableCodeCoverage /Collect:"Code Coverage;Format=Xml" `
+            /ResultsDirectory:"${{ github.workspace }}/x64" `
+            /Settings:"${{ github.workspace }}/test.runsettings"
         working-directory: x64/Debug/UnitTestApp1
 
       - uses: actions/cache@v4.3.0

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -61,15 +61,16 @@ jobs:
 
       - name: "Run build-wrapper(x64/Debug)"
         run: |
-          build-wrapper-win-x86-64 --out-dir bw-output `
+          build-wrapper-win-x86-64 --out-dir "bw-output" `
             MSBuild windows-experiment.sln "/t:Shared1;App1;UnitTestApp1" /p:platform="x64" /p:configuration="Debug" `
               /nodeReuse:false /p:BuildProjectReferences=false
         env:
           VCPKG_FEATURE_FLAGS: "registries,binarycaching,manifests"
 
-      - name: "Run VSTest(x64/Debug)"
+      - name: "Run VSTest(x64/Debug)" # see https://github.com/sonarsource-cfamily-examples/windows-msbuild-vscoverage-gh-actions-sc
         run: |
-          vstest.console.exe /framework:frameworkuap10 UnitTestApp1.build.appxrecipe
+          vstest.console.exe /framework:frameworkuap10 UnitTestApp1.build.appxrecipe `
+            /EnableCodeCoverage /Collect:"Code Coverage;Format=Xml" "/ResultsDirectory:${{ github.workspace }}/x64"
         working-directory: x64/Debug/UnitTestApp1
 
       - uses: actions/cache@v4.3.0
@@ -88,3 +89,4 @@ jobs:
           args: >
             --define "sonar.token=${{ secrets.SONAR_TOKEN }}"
             --define "sonar.cfamily.build-wrapper-output=bw-output"
+            --define "sonar.cfamily.vscoveragexml.reportsPath=x64/*.xml"

--- a/Shared1/BasicViewModel.cpp
+++ b/Shared1/BasicViewModel.cpp
@@ -30,7 +30,7 @@ StorageFolder BasicViewModel::GetLogFolder() {
 
 winrt::hstring BasicViewModel::GetLogFolderPath() {
     if (m_log_folder == nullptr)
-        throw std::runtime_error("Log folder not initialized");
+        throw winrt::hresult_error{E_FAIL, L"call CreateLogFolderAsync before this function"};
     return m_log_folder.Path();
 }
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,14 +1,8 @@
-#
-# References
-#   - https://docs.sonarqube.org/latest/analysis/analysis-parameters/
-#   - https://docs.sonarqube.org/latest/analysis/languages/cfamily/
-#   - https://docs.sonarqube.org/latest/analysis/coverage/
-#
 sonar.organization=luncliff-github
 sonar.host.url=https://sonarcloud.io
 
-sonar.projectKey=luncliff_windows-experiment
-sonar.projectName=luncliff_windows-experiment
+sonar.projectKey=luncliff-windows-experiment
+sonar.projectName=luncliff-windows-experiment
 sonar.projectDescription=Personal Windows SDK experiments
 sonar.projectVersion=0.2540.0
 

--- a/test.runsettings
+++ b/test.runsettings
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- File name extension must be .runsettings -->
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="Code Coverage" uri="datacollector://Microsoft/CodeCoverage/2.0" assemblyQualifiedName="Microsoft.VisualStudio.Coverage.DynamicCoverageDataCollector, Microsoft.VisualStudio.TraceCollector, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+        <Configuration>
+          <Format>coverage</Format>
+          <CodeCoverage>
+            <!-- Use the absolute path in GitHub hosted Windows runners -->
+            <SymbolSearchPaths>
+              <Path>D:\a\windows-experiment\windows-experiment\x64\Debug\</Path>
+              <Path>D:\a\windows-experiment\windows-experiment\x64\Debug\App1</Path>
+            </SymbolSearchPaths>
+
+            <ModulePaths>
+              <Include>
+                <ModulePath>.*\.dll$</ModulePath>
+                <ModulePath>.*\.exe$</ModulePath>
+              </Include>
+              <Exclude>
+                <ModulePath>.*CPPUnitTestFramework.*</ModulePath>
+              </Exclude>
+            </ModulePaths>
+
+            <UseVerifiableInstrumentation>True</UseVerifiableInstrumentation>
+            <AllowLowIntegrityProcesses>True</AllowLowIntegrityProcesses>
+            <CollectFromChildProcesses>True</CollectFromChildProcesses>
+            <CollectAspDotNet>False</CollectAspDotNet>
+            <EnableStaticNativeInstrumentation>True</EnableStaticNativeInstrumentation>
+            <EnableDynamicNativeInstrumentation>True</EnableDynamicNativeInstrumentation>
+            <EnableStaticNativeInstrumentationRestore>True</EnableStaticNativeInstrumentationRestore>
+            <IncludeTestAssembly>True</IncludeTestAssembly>
+          </CodeCoverage>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -14,7 +14,7 @@
                 "opencl-headers",
                 "opencl"
             ],
-            "baseline": "700dfc4647f97686bac8a7fcddbf7a31592ccfa1"
+            "baseline": "7a2f5e6bc2171d5f9399e77ce256d6cbcb6f17bb"
         }
     ]
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,13 +1,20 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "windows-experiment",
-  "version": "0.2525.0",
+  "version": "0.2540.0",
   "description": "Personal Windows SDK experiments",
   "homepage": "https://github.com/luncliff/windows-experiment",
   "license": "CC0-1.0",
   "supports": "windows",
   "dependencies": [
-    "opencl",
+    {
+      "name": "opencl",
+      "version>=": "v2024.10.24"
+    },
+    {
+      "name": "opencl-headers",
+      "version>=": "v2024.10.24"
+    },
     "spdlog"
   ]
 }


### PR DESCRIPTION
# Code Coverage Analysis Notes for WinUI 3 / GitHub Actions

## Microsoft Documentation

- [Configure unit tests by using a .runsettings file](https://learn.microsoft.com/en-us/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file?view=vs-2022)  
  Explains how to customize test runs with `.runsettings`, including enabling data collectors like **Code Coverage**.

- [vstest.console.exe command-line options](https://learn.microsoft.com/en-us/visualstudio/test/vstest-console-options?view=vs-2022#uwp-example)  
  Lists all options for `vstest.console.exe`. Includes a **UWP example** showing how to run tests against an `.appxrecipe`.

- [Troubleshooting code coverage](https://learn.microsoft.com/en-us/troubleshoot/developer/visualstudio/ide/troubleshooting-code-coverage)  
  Covers common issues with Visual Studio’s built-in code coverage, including requirements (Enterprise edition) and limitations in certain environments.

## GitHub Actions Runner Images

- [Windows Server 2025 runner image](https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md)  
  Details the software installed on the `windows-latest` runner (currently Windows Server 2025). Confirms **Visual Studio Enterprise 2022** is included.

- [Windows Server 2022 runner image](https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md)  
  Similar to the above, but for the older Windows Server 2022 image. Useful for comparing installed components across environments.

## Third-Party Tools

- [OpenCppCoverage](https://github.com/OpenCppCoverage/OpenCppCoverage)  
  An open-source code coverage tool for native C++ projects. Can generate Cobertura/LCOV reports, making it suitable for CI/CD pipelines where Visual Studio’s profiler cannot attach (e.g., AppContainer scenarios).

- [Coverlet (NuGet)](https://www.nuget.org/packages/coverlet.collector)  
  Widely used in .NET projects for cross-platform code coverage collection. Works with `dotnet test` and produces Cobertura/LCOV/JaCoCo output. Not directly applicable to C++/WinRT, but useful for understanding how C# projects avoid AppContainer issues.

---

## AppContainer Sandbox

- **Definition**: AppContainer is a Windows sandbox used by UWP and packaged WinUI apps. It enforces strict isolation for security, limiting process injection, file system access, and profiler attachment.  
- **Impact on Code Coverage**: Visual Studio’s code coverage engine works by injecting a profiler DLL into the test process. In AppContainer, this injection is blocked by design, leading to the error:  
  *“Data collector 'Code Coverage' message: No code coverage data available. Profiler was not initialized.”*  
- **Result**: Any test executed inside a packaged `.appxrecipe` will fail to produce coverage data, even when using Visual Studio Enterprise.

---

## C++/WinRT Project Strategy

- **Problem**: C++/WinRT + WinUI 3 projects often run tests inside the packaged app container, where coverage cannot be collected.  
- **Recommended Strategy**:
  - Factor core business logic into a **static library or DLL**.  
  - Write unit tests against that library in a **non-packaged test project** (e.g., MSTest, GoogleTest).  
  - Run those tests in CI with `vstest.console.exe` or `ctest` + a coverage tool (Visual Studio native coverage or OpenCppCoverage).  
  - Reserve packaged `.appxrecipe` tests for UI/AppContainer-specific behavior, but don’t expect coverage there.  

This mirrors the approach taken in C#/.NET projects, where core logic is tested outside AppContainer and coverage is collected with Coverlet.

---

## Lessons Learned / Summary

1. **Environment**: GitHub-hosted Windows runners (`windows-latest`) now use Windows Server 2025 and include Visual Studio Enterprise 2022. So the profiler binaries are present.  
2. **Root Cause**: The **AppContainer sandbox** prevents profiler injection, not the absence of Enterprise edition.  
3. **C# vs. C++**:  
   - C# projects avoid this issue by testing outside AppContainer and using Coverlet/XPlat coverage.  
   - C++/WinRT projects must adopt a similar strategy: test core logic outside the packaged app, and use tools like OpenCppCoverage for Cobertura/LCOV output.  
4. **Practical Outcome**:  
   - Packaged `.appxrecipe` tests cannot produce coverage in CI.  
   - To get coverage reports in GitHub Actions, restructure tests or use alternative coverage tools.  

---

- Resolve https://github.com/luncliff/windows-experiment/issues/8

```log
Data collector 'Code Coverage' message: No code coverage data available. Profiler was not initialized..
```

## References

- https://learn.microsoft.com/en-us/troubleshoot/developer/visualstudio/ide/troubleshooting-code-coverage
- https://learn.microsoft.com/en-us/visualstudio/test/using-code-coverage-to-determine-how-much-code-is-being-tested?view=vs-2022&tabs=cpp
- https://learn.microsoft.com/en-us/visualstudio/test/customizing-code-coverage-analysis?view=vs-2022#code-coverage-formats