### PR TITLE
Make Single instance App, Share ViewModelProvider in App Launched 

### DIFF
--- a/App1/App.xaml.cpp
+++ b/App1/App.xaml.cpp
@@ -15,19 +15,12 @@ using namespace std::placeholders;
 using namespace Windows::Foundation;
 using namespace Microsoft::UI::Xaml::Controls;
 using namespace Microsoft::UI::Xaml::Navigation;
-using Microsoft::UI::Xaml::ApplicationTheme;
 
 App::App() noexcept(false) {
     InitializeComponent();
-    set_log_stream("App");
 #if defined _DEBUG && !defined DISABLE_XAML_GENERATED_BREAK_ON_UNHANDLED_EXCEPTION
-    //auto handler = std::bind(&App::OnUnhandledException, this, _1, _2);
     UnhandledException({this, &App::OnUnhandledException});
 #endif
-    RequestedTheme(ApplicationTheme::Dark);
-    settings = winrt::make<implementation::SettingsViewModel>();
-    // note: the App will be the first which receives the events
-    settings_changed_token = settings.PropertyChanged({this, &App::on_settings_changed});
 }
 
 App::~App() noexcept {
@@ -43,6 +36,9 @@ void App::OnUnhandledException(IInspectable const&, UnhandledExceptionEventArgs 
 
 void App::OnLaunched(LaunchActivatedEventArgs const&) {
     spdlog::info("App: {:s}", std::source_location::current().function_name());
+    settings = winrt::make<implementation::SettingsViewModel>();
+    // note: the App will be the first which receives the events
+    settings_changed_token = settings.PropertyChanged({this, &App::on_settings_changed});
     auto impl = winrt::make<implementation::MainWindow>();
     impl.Settings(settings);
     window = impl;
@@ -65,3 +61,28 @@ void App::clear_settings_event() noexcept {
 }
 
 } // namespace winrt::App1::implementation
+
+/// @see https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/migrate-to-windows-app-sdk/guides/applifecycle#single-instancing-in-main-or-wwinmain
+int WINAPI wWinMain(HINSTANCE, HINSTANCE, PWSTR, int) {
+    winrt::init_apartment(winrt::apartment_type::single_threaded);
+
+    // try creation of named mutex to enforce single instance
+    winrt::handle mutex{CreateMutexW(nullptr, true, L"We miss you so much")};
+    if (static_cast<bool>(mutex) == false) {
+        const auto ec = GetLastError();
+        if (ec == ERROR_ALREADY_EXISTS) // another instance is running
+            return S_OK;
+        return ec; // mutex creation failed
+    }
+
+    // setup the logger and print the current executable's path
+    winrt::App1::set_log_stream("App");
+    auto exe = winrt::App1::get_module_path();
+    spdlog::debug(L"{}", exe.native());
+
+    winrt::Microsoft::UI::Xaml::Application::Start([](auto&&) {
+        // ... start the application lifecycle ...
+        winrt::make<winrt::App1::implementation::App>();
+    });
+    return S_OK;
+}

--- a/App1/App.xaml.h
+++ b/App1/App.xaml.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "App.xaml.g.h"
-#include "SettingsViewModel.g.h"
+#include "ViewModelProvider.g.h"
 
 namespace winrt::App1::implementation {
 using Microsoft::UI::Xaml::LaunchActivatedEventArgs;
@@ -12,7 +12,7 @@ using Windows::Foundation::IInspectable;
 struct App : AppT<App> {
   private:
     Window window = nullptr;
-    App1::SettingsViewModel settings = nullptr;
+    App1::ViewModelProvider provider{};
     winrt::event_token settings_changed_token{};
 
   public:

--- a/App1/App1.vcxproj
+++ b/App1/App1.vcxproj
@@ -115,7 +115,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
-      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions);WIN32_LEAN_AND_MEAN;SPDLOG_USE_STD_FORMAT</PreprocessorDefinitions>
+      <PreprocessorDefinitions>DISABLE_XAML_GENERATED_MAIN;_DEBUG;%(PreprocessorDefinitions);WIN32_LEAN_AND_MEAN;SPDLOG_USE_STD_FORMAT</PreprocessorDefinitions>
       <EnableModules Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">false</EnableModules>
       <BuildStlModules Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">false</BuildStlModules>
       <EnableModules Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</EnableModules>
@@ -134,7 +134,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
     <ClCompile>
-      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions);WIN32_LEAN_AND_MEAN;SPDLOG_USE_STD_FORMAT</PreprocessorDefinitions>
+      <PreprocessorDefinitions>DISABLE_XAML_GENERATED_MAIN;NDEBUG;%(PreprocessorDefinitions);WIN32_LEAN_AND_MEAN;SPDLOG_USE_STD_FORMAT</PreprocessorDefinitions>
       <EnableModules Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">false</EnableModules>
       <BuildStlModules Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">false</BuildStlModules>
       <EnableModules Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</EnableModules>

--- a/App1/App1.vcxproj
+++ b/App1/App1.vcxproj
@@ -170,6 +170,10 @@
       <SubType>Code</SubType>
       <DependentUpon>SettingsViewModel.idl</DependentUpon>
     </ClInclude>
+    <ClInclude Include="ViewModelProvider.h">
+      <SubType>Code</SubType>
+      <DependentUpon>ViewModelProvider.idl</DependentUpon>
+    </ClInclude>
     <ClInclude Include="StepTimer.h" />
     <ClInclude Include="TestPage1.xaml.h">
       <DependentUpon>TestPage1.xaml</DependentUpon>
@@ -220,6 +224,10 @@
       <SubType>Code</SubType>
       <DependentUpon>SettingsViewModel.idl</DependentUpon>
     </ClCompile>
+    <ClCompile Include="ViewModelProvider.cpp">
+      <SubType>Code</SubType>
+      <DependentUpon>ViewModelProvider.idl</DependentUpon>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Midl Include="MainWindow.idl">
@@ -239,6 +247,9 @@
       <SubType>Code</SubType>
     </Midl>
     <Midl Include="SettingsViewModel.idl">
+      <SubType>Code</SubType>
+    </Midl>
+    <Midl Include="ViewModelProvider.idl">
       <SubType>Code</SubType>
     </Midl>
   </ItemGroup>

--- a/App1/MainWindow.idl
+++ b/App1/MainWindow.idl
@@ -1,4 +1,4 @@
-import "SettingsViewModel.idl";
+import "ViewModelProvider.idl";
 
 namespace App1 {
 
@@ -7,6 +7,9 @@ namespace App1 {
     MainWindow();
 
     SettingsViewModel Settings {
+        get;
+    };
+    ViewModelProvider Provider {
         get;
         set;
     };

--- a/App1/MainWindow.xaml.cpp
+++ b/App1/MainWindow.xaml.cpp
@@ -42,9 +42,8 @@ void MainWindow::Provider(App1::ViewModelProvider value) noexcept(false) {
     if (value == nullptr)
         throw winrt::hresult_invalid_argument(L"ViewModelProvider cannot be null");
     provider = value;
-    auto settings = provider.Settings();
-    if (settings != nullptr)
-        settings_changed_token = provider.Settings().PropertyChanged({this, &MainWindow::on_settings_changed});
+    if (auto settings = provider.Settings(); settings != nullptr)
+        settings_changed_token = settings.PropertyChanged({this, &MainWindow::on_settings_changed});
 }
 
 App1::SettingsViewModel MainWindow::Settings() const noexcept {
@@ -78,13 +77,12 @@ void MainWindow::on_window_visibility_changed(IInspectable const&, WindowVisibil
     spdlog::info("{}: visibility {}", "MainWindow", e.Visible());
 }
 
+/// @see https://learn.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.frame.navigate
 void MainWindow::on_item_invoked(NavigationView const&, NavigationViewItemInvokedEventArgs const& e) {
-    // there are very limited types for params... read the document.
-    // see https://learn.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.frame.navigate
     Frame frame = ShellFrame();
     if (e.IsSettingsInvoked()) {
         // SettingsPage will use the SettingsViewModel
-        frame.Navigate(xaml_typename<App1::SettingsPage>(), Settings());
+        frame.Navigate(xaml_typename<App1::SettingsPage>(), Provider());
         return;
     }
 
@@ -92,13 +90,14 @@ void MainWindow::on_item_invoked(NavigationView const&, NavigationViewItemInvoke
     if (item == nullptr)
         return;
 
+    // Sharing the ViewModelProvider means that the Page can access multiple ViewModels for its logics and UserControls
     auto tag = unbox_value_or<winrt::hstring>(item.Tag(), L"");
     if (tag == L"TestPage1") {
         frame.Navigate(xaml_typename<App1::TestPage1>(), Provider().Basic());
         return;
     }
     if (tag == L"SupportPage") {
-        frame.Navigate(xaml_typename<App1::SupportPage>(), Provider().Basic());
+        frame.Navigate(xaml_typename<App1::SupportPage>(), Provider());
         return;
     }
 }

--- a/App1/MainWindow.xaml.h
+++ b/App1/MainWindow.xaml.h
@@ -24,16 +24,17 @@ using Windows::Foundation::IInspectable;
 /// @see http://aka.ms/winui-project-info
 struct MainWindow : MainWindowT<MainWindow> {
   private:
-    Shared1::BasicViewModel viewmodel0 = nullptr;
-    App1::SettingsViewModel viewmodel1 = nullptr;
+    App1::ViewModelProvider provider = nullptr;
     winrt::event_token settings_changed_token{};
 
   public:
     MainWindow() noexcept(false);
     ~MainWindow() noexcept;
 
+    App1::ViewModelProvider Provider() const noexcept;
+    void Provider(App1::ViewModelProvider) noexcept(false);
+
     App1::SettingsViewModel Settings() const noexcept;
-    void Settings(App1::SettingsViewModel) noexcept(false);
 
     uint64_t WindowHandle() const noexcept;
 

--- a/App1/SettingsPage.xaml.cpp
+++ b/App1/SettingsPage.xaml.cpp
@@ -4,73 +4,64 @@
 #if __has_include("SettingsPage.g.cpp")
 #include "SettingsPage.g.cpp"
 #endif
-
-#define SPDLOG_WCHAR_TO_UTF8_SUPPORT
-#include <spdlog/spdlog.h>
+#include "ViewModelProvider.g.h"
 
 namespace winrt::App1::implementation {
-
-using Windows::Foundation::Uri;
-using Windows::System::Launcher;
-using Microsoft::UI::Xaml::Data::PropertyChangedEventArgs;
 
 App1::SettingsViewModel SettingsPage::ViewModel() noexcept {
     return viewmodel0;
 }
 
-void SettingsPage::OnNavigatedTo(const NavigationEventArgs& e) {
-    IInspectable arg0 = e.Parameter();
+void SettingsPage::setup_viewmodels(IInspectable arg0) noexcept(false) {
     if (arg0 == nullptr)
-        throw std::runtime_error("SettingsPage requires a ViewModel");
-    viewmodel0 = arg0.try_as<App1::SettingsViewModel>();
+        throw winrt::hresult_invalid_argument{L"Navigation parameter is null"};
+    auto provider = arg0.try_as<App1::ViewModelProvider>();
+    if (provider == nullptr)
+        throw winrt::hresult_invalid_argument{L"Navigation parameter is not a ViewModelProvider"};
+    if ((viewmodel0 = provider.Settings()) == nullptr)
+        throw winrt::hresult_invalid_argument{L"ViewModel is null"};
+}
+
+void SettingsPage::OnNavigatedTo(const NavigationEventArgs& e) {
+    // Get the ViewModel from the navigation parameter. Ensure ViewModel is always valid
+    setup_viewmodels(e.Parameter());
 
     // Connect to property changed events
-    if (viewmodel0 != nullptr) {
-        property_changed_token = viewmodel0.PropertyChanged({this, &SettingsPage::on_settings_property_changed});
-        UpdateCounterDisplay();
-    }
+    settings_changed_token = ViewModel().PropertyChanged({this, &SettingsPage::on_settings_property_changed});
+    UpdateCounterDisplay();
 }
 
 void SettingsPage::OnNavigatedFrom(const NavigationEventArgs&) {
     // Disconnect from property changed events
-    if (viewmodel0 != nullptr && property_changed_token) {
-        viewmodel0.PropertyChanged(property_changed_token);
-        property_changed_token = {};
+    if (settings_changed_token) {
+        viewmodel0.PropertyChanged(settings_changed_token);
+        settings_changed_token = {};
     }
     viewmodel0 = nullptr;
 }
 
 void SettingsPage::UpdateCounterDisplay() {
-    if (viewmodel0 != nullptr) {
-        CounterTextBlock().Text(winrt::to_hstring(viewmodel0.Counter()));
-    }
+    CounterTextBlock().Text(winrt::to_hstring(ViewModel().Counter()));
 }
 
-void SettingsPage::on_settings_property_changed(IInspectable const&, Microsoft::UI::Xaml::Data::PropertyChangedEventArgs const& e) {
+void SettingsPage::on_settings_property_changed(IInspectable const&, PropertyChangedEventArgs const& e) {
     if (e.PropertyName() == L"Counter") {
         UpdateCounterDisplay();
     }
 }
 
 void SettingsPage::on_increment_counter_click(IInspectable const&, RoutedEventArgs const&) {
-    if (viewmodel0 != nullptr) {
-        viewmodel0.Counter(viewmodel0.Counter() + 1);
-    }
+    ViewModel().Counter(ViewModel().Counter() + 1);
 }
 
 void SettingsPage::on_decrement_counter_click(IInspectable const&, RoutedEventArgs const&) {
-    if (viewmodel0 != nullptr) {
-        uint32_t currentValue = viewmodel0.Counter();
-        if (currentValue > 0) {
-            viewmodel0.Counter(currentValue - 1);
-        }
-    }
+    uint32_t value = ViewModel().Counter();
+    if (value > 0)
+        ViewModel().Counter(value - 1);
 }
 
 void SettingsPage::on_reset_counter_click(IInspectable const&, RoutedEventArgs const&) {
-    if (viewmodel0 != nullptr) {
-        viewmodel0.ResetToDefault();
-    }
+    ViewModel().ResetToDefault();
 }
 
 } // namespace winrt::App1::implementation

--- a/App1/SettingsPage.xaml.h
+++ b/App1/SettingsPage.xaml.h
@@ -5,15 +5,15 @@
 
 namespace winrt::App1::implementation {
 using Microsoft::UI::Xaml::RoutedEventArgs;
-using Microsoft::UI::Xaml::Data::PropertyChangedEventHandler;
 using Microsoft::UI::Xaml::Data::PropertyChangedEventArgs;
+using Microsoft::UI::Xaml::Data::PropertyChangedEventHandler;
 using Microsoft::UI::Xaml::Navigation::NavigationEventArgs;
 using Windows::Foundation::IInspectable;
 
 struct SettingsPage : SettingsPageT<SettingsPage> {
   private:
     App1::SettingsViewModel viewmodel0{nullptr};
-    winrt::event_token property_changed_token{};
+    winrt::event_token settings_changed_token{};
 
     void UpdateCounterDisplay();
     void on_settings_property_changed(IInspectable const& sender, PropertyChangedEventArgs const& e);
@@ -25,7 +25,8 @@ struct SettingsPage : SettingsPageT<SettingsPage> {
     void OnNavigatedFrom(const NavigationEventArgs&);
 
     App1::SettingsViewModel ViewModel() noexcept;
-    
+
+    void setup_viewmodels(IInspectable) noexcept(false);
     void on_increment_counter_click(IInspectable const&, RoutedEventArgs const&);
     void on_decrement_counter_click(IInspectable const&, RoutedEventArgs const&);
     void on_reset_counter_click(IInspectable const&, RoutedEventArgs const&);

--- a/App1/SupportPage.xaml.cpp
+++ b/App1/SupportPage.xaml.cpp
@@ -4,11 +4,18 @@
 #if __has_include("SupportPage.g.cpp")
 #include "SupportPage.g.cpp"
 #endif
+#include "ViewModelProvider.g.h"
 
 namespace winrt::App1::implementation {
 
-SupportPage::SupportPage() {
-    // Initialize support page
+void SupportPage::setup_viewmodels(IInspectable arg0) noexcept(false) {
+    if (arg0 == nullptr)
+        throw winrt::hresult_invalid_argument{L"Navigation parameter is null"};
+    auto provider = arg0.try_as<App1::ViewModelProvider>();
+    if (provider == nullptr)
+        throw winrt::hresult_invalid_argument{L"Navigation parameter is not a ViewModelProvider"};
+    if ((viewmodel0 = provider.Basic()) == nullptr)
+        throw winrt::hresult_invalid_argument{L"ViewModel is null"};
 }
 
 Shared1::BasicViewModel SupportPage::ViewModel() noexcept {
@@ -16,18 +23,13 @@ Shared1::BasicViewModel SupportPage::ViewModel() noexcept {
 }
 
 void SupportPage::OnNavigatedTo(const NavigationEventArgs& e) {
-    if (e == nullptr)
-        return;
-
-    // Get the ViewModel from the navigation parameter
-    if (e.Parameter() != nullptr) {
-        viewmodel0 = e.Parameter().try_as<Shared1::BasicViewModel>();
-        // ViewModel is available for future use in the support page
-    }
+    // Get the ViewModel from the navigation parameter. Ensure ViewModel is always valid
+    setup_viewmodels(e.Parameter());
 }
 
 void SupportPage::OnNavigatedFrom(const NavigationEventArgs&) {
     // Handle leaving the page via navigation
+    viewmodel0 = nullptr;
 }
 
 } // namespace winrt::App1::implementation

--- a/App1/SupportPage.xaml.h
+++ b/App1/SupportPage.xaml.h
@@ -11,12 +11,15 @@ struct SupportPage : SupportPageT<SupportPage> {
     Shared1::BasicViewModel viewmodel0{nullptr};
 
   public:
-    SupportPage();
+    SupportPage() noexcept = default;
 
     void OnNavigatedTo(const NavigationEventArgs&);
     void OnNavigatedFrom(const NavigationEventArgs&);
 
     Shared1::BasicViewModel ViewModel() noexcept;
+
+  private:
+    void setup_viewmodels(IInspectable) noexcept(false);
 };
 } // namespace winrt::App1::implementation
 

--- a/App1/ViewModelProvider.cpp
+++ b/App1/ViewModelProvider.cpp
@@ -17,7 +17,7 @@ App1::SettingsViewModel ViewModelProvider::Settings() const noexcept {
 
 void ViewModelProvider::Settings(App1::SettingsViewModel viewmodel) noexcept(false) {
     if (viewmodel == nullptr)
-        throw winrt::hresult_invalid_argument{};
+        throw winrt::hresult_invalid_argument{L"SettingsViewModel cannot be null"};
     settings = viewmodel;
 }
 

--- a/App1/ViewModelProvider.cpp
+++ b/App1/ViewModelProvider.cpp
@@ -1,0 +1,24 @@
+#include "pch.h"
+
+#include "ViewModelProvider.h"
+#if __has_include("ViewModelProvider.g.cpp")
+#include "ViewModelProvider.g.cpp"
+#endif
+
+namespace winrt::App1::implementation {
+
+Shared1::BasicViewModel ViewModelProvider::Basic() const noexcept {
+    return basic;
+}
+
+App1::SettingsViewModel ViewModelProvider::Settings() const noexcept {
+    return settings;
+}
+
+void ViewModelProvider::Settings(App1::SettingsViewModel viewmodel) noexcept(false) {
+    if (viewmodel == nullptr)
+        throw winrt::hresult_invalid_argument{};
+    settings = viewmodel;
+}
+
+} // namespace winrt::App1::implementation

--- a/App1/ViewModelProvider.h
+++ b/App1/ViewModelProvider.h
@@ -1,0 +1,26 @@
+#pragma once
+#include "ViewModelProvider.g.h"
+
+#include "SettingsViewModel.g.h"
+
+namespace winrt::App1::implementation {
+
+struct ViewModelProvider : ViewModelProviderT<ViewModelProvider> {
+    Shared1::BasicViewModel basic{};
+    App1::SettingsViewModel settings{nullptr};
+
+  public:
+    ViewModelProvider() noexcept = default;
+
+    Shared1::BasicViewModel Basic() const noexcept;
+    App1::SettingsViewModel Settings() const noexcept;
+    void Settings(App1::SettingsViewModel) noexcept(false);
+};
+
+} // namespace winrt::App1::implementation
+
+namespace winrt::App1::factory_implementation {
+
+struct ViewModelProvider : ViewModelProviderT<ViewModelProvider, implementation::ViewModelProvider> {};
+
+} // namespace winrt::App1::factory_implementation

--- a/App1/ViewModelProvider.idl
+++ b/App1/ViewModelProvider.idl
@@ -1,0 +1,17 @@
+import "SettingsViewModel.idl";
+
+namespace App1 {
+
+[default_interface] runtimeclass ViewModelProvider {
+    ViewModelProvider();
+
+    Shared1.BasicViewModel Basic {
+        get;
+    };
+    SettingsViewModel Settings {
+        get;
+        set;
+    };
+}
+
+} // namespace App1

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Check current [concerns](./developer-concerns.md) and upcoming [work items](./TO
 vcpkg integrate install
 ```
 
-We have to restore packages in [packages.config](./App1/packages.config).
+We have to restore packages in [packages.config](./packages.config).
+The NuGet artifacts will be located in [packages folder](./packages/).
 
 ```ps1
 # nuget restore windows-experiment.sln
@@ -30,7 +31,11 @@ nuget restore packages.config -SolutionDirectory .
 
 ### Build
 
-Build the solution file, or [App1](./App1/App1.vcxproj) VC++ project.
+Build the solution file
+
+- [Shared1](./Shared1/Shared1.vcxproj) implements some Models and ViewModels
+- [App1](./App1/App1.vcxproj) implements the application
+- [App1Package](./App1Package/App1Package.vcxproj) is a Windows Application Packaging project for this repository
 
 ```ps1
 # Full build of the projects
@@ -74,28 +79,33 @@ The snippet just show that we will use App1Package project. Not a correct comman
 
 - https://github.com/PacktPublishing/Modernizing-Your-Windows-Applications-with-the-Windows-Apps-SDK-and-WinUI
 - https://github.com/microsoft/WindowsAppSDK-Samples
+- [Create your first WinUI 3 (Windows App SDK) project](https://learn.microsoft.com/en-us/windows/apps/winui/winui3/create-your-first-winui3-app)
 
 ### Additional (Design & Implementation)
 
-WinUI / Controls
-- WinUI Controls (API Overview): https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls?view=windows-app-sdk-1.7
+#### WinUI 3, [C++/WinRT](https://learn.microsoft.com/en-us/windows/uwp/cpp-and-winrt-apis/)
+
+- [Microsoft.UI.Xaml.Controls Namespace](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls?view=windows-app-sdk-1.7)
 - https://github.com/Lewis-Marshall/WinUI3NavigationExample
 
-Diagnostics & Logging
+Sadly, we can't use CommunityToolkit.
+
+```log
+Could not install package 'CommunityToolkit.WinUI.Controls.Primitives 8.2.250402'. You are trying to install this package into a project that targets 'native,Version=v0.0', but the package does not contain any assembly references or content files that are compatible with that framework.
+```
+
+- [Windows Community Toolkit Documentation](https://learn.microsoft.com/en-us/dotnet/communitytoolkit/windows/)
+- https://github.com/CommunityToolkit/Windows
+
+#### Diagnostics & Logging
 - LoggingChannel: https://learn.microsoft.com/en-us/uwp/api/windows.foundation.diagnostics.loggingchannel
 - LoggingSession: https://learn.microsoft.com/en-us/uwp/api/windows.foundation.diagnostics.loggingsession
 
-DirectX & Interop
-- DirectX 12 Programming Guide: https://learn.microsoft.com/en-us/windows/win32/direct3d12/directx-12-programming-guide
-- SwapChainPanel Interop (`ISwapChainPanelNative`): https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/win32/microsoft.ui.xaml.media.dxinterop/nn-microsoft-ui-xaml-media-dxinterop-iswapchainpanelnative
-- DirectX Graphics Samples: https://github.com/microsoft/DirectX-Graphics-Samples
+#### DirectX & DXGI Interop
 
-C++/WinRT & MVVM
-- C++/WinRT Overview: https://learn.microsoft.com/en-us/windows/uwp/cpp-and-winrt-apis/
-- Community MVVM Guidance (assorted blog/sample references – to curate)
-
-Future / Extended
-- Potential Telemetry Channel (deferred): evaluate after core logging adapter integration.
+- [DirectX 12 Programming Guide](https://learn.microsoft.com/en-us/windows/win32/direct3d12/directx-12-programming-guide)
+- [SwapChainPanel Interop (`ISwapChainPanelNative` in `Microsoft.UI.Xaml` namespace)](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/win32/microsoft.ui.xaml.media.dxinterop/nn-microsoft-ui-xaml-media-dxinterop-iswapchainpanelnative)
+- https://github.com/microsoft/DirectX-Graphics-Samples
 
 ### Future Works
 

--- a/TODO.md
+++ b/TODO.md
@@ -40,6 +40,7 @@ High-Level Tasks:
 - Add lightweight timing helper (RAII scope logger) integrated with adapter.
 - Conditional compilation flags for high-frequency DX diagnostics.
 - Explore integration with ETW consumer tooling (trace session guidelines doc).
+- Potential Telemetry Channel (deferred): evaluate after core logging adapter integration.
 
 ## 5. Reliability / Resilience
 - Introduce retry/backoff for settings persistence failures.

--- a/packages.config
+++ b/packages.config
@@ -15,4 +15,6 @@
   <!-- Web and Additional Components -->
   <package id="Microsoft.Web.WebView2" version="1.0.3351.48" targetFramework="native" />
   <package id="Microsoft.Windows.SDK.BuildTools" version="10.0.26100.4188" targetFramework="native" />
+ 
+  <!-- WinUI 3 and CommunityToolkit is not available because the project is using "native" target framework -->
 </packages>


### PR DESCRIPTION
## Changes

- Make more clear ViewModel creation and access between App - MainWindow - Page
- Ensure App is single instanced, using Win32 Mutex (wrapped in `winrt::handle`)

Because ViewModelProvider is a runtimeclass for App1 project, we won't test the class.

### Documentation

- Tried to apply CommunityToolKit in WinUI 3 C++ project, but the `native` framework is not supported.